### PR TITLE
Include planet python client

### DIFF
--- a/modules/geospatial-toolkit/docker/config/requirements.txt
+++ b/modules/geospatial-toolkit/docker/config/requirements.txt
@@ -14,6 +14,7 @@ geopandas
 matplotlib
 pandas
 dask[complete]
+planet
 
 ########  Google Earthengine  ########
 oauth2client


### PR DESCRIPTION
Some modules are using Python client for Planet APIs, the library provides a command-line-interface (CLI) and Python library to make access to Planet’s public API easy to use.
More info: 
- https://github.com/planetlabs/planet-client-python
- https://planetlabs.github.io/planet-client-python/index.html