### PR TITLE
wire the github repo

### DIFF
--- a/modules/gui/frontend/src/app/home/footer/footer.js
+++ b/modules/gui/frontend/src/app/home/footer/footer.js
@@ -46,7 +46,7 @@ const Logout = () =>
         tooltipPlacement='top'/>
 
 const Title = () => {
-    const wikiURL = 'https://github.com/openforis/sepal/wiki'
+    const wikiURL = 'https://github.com/openforis/sepal'
     const buildNumber = process.env.REACT_APP_BUILD_NUMBER
     const gitCommit = process.env.REACT_APP_GIT_COMMIT
     const gitShortCommit = gitCommit && `${gitCommit.substring(0, 10)}...`


### PR DESCRIPTION
wire the github repository to the sepal button instead of the wiki. Now that there is a purely dedicated doc button, I think it make more sense to just point to the github repo