### PR TITLE
Debug slope correction

### DIFF
--- a/lib/js/shared/src/ee/radar/terrainCorrection.js
+++ b/lib/js/shared/src/ee/radar/terrainCorrection.js
@@ -57,6 +57,7 @@ var terrainCorrection = function(image, options) {
     }
 
     function _correct(image) {
+        
         // get image geometry and projection
         var geom = image.geometry()
         var proj = image.select(1).projection()
@@ -73,16 +74,38 @@ var terrainCorrection = function(image, options) {
         heading = ee.Dictionary(heading).combine({
             aspect: 0
         }, false).get('aspect')
-
+        
+        heading = ee.Algorithms.If(
+            ee.Number(heading).gt(180),
+            ee.Number(heading).subtract(360),
+            ee.Number(heading)
+        )
+        
         // the numbering follows the article chapters
         // 2.1.1 Radar geometry
         var theta_iRad = image.select('angle').multiply(Math.PI / 180).clip(geom)
         var phi_iRad = ee.Image.constant(heading).multiply(Math.PI / 180)
 
         // 2.1.2 Terrain geometry
-        var alpha_sRad = ee.Terrain.slope(elevation).select('slope').multiply(Math.PI / 180).setDefaultProjection(proj).clip(geom)
-        var phi_sRad = ee.Terrain.aspect(elevation).select('aspect').multiply(Math.PI / 180).setDefaultProjection(proj).clip(geom)
+        //slope 
+        var alpha_sRad = ee.Terrain.slope(elevation).select('slope').multiply(Math.PI / 180)
+        
+        // aspect (-180 to 180)
+        var aspect = ee.Terrain.aspect(elevation).select('aspect').clip(geom)
+        
+        // we need to subtract 360 degree from all values above 180 degree
+        var aspect_minus = aspect
+          .updateMask(aspect.gt(180))
+          .subtract(360)
 
+        // we fill the aspect layer with the subtracted values from aspect_minus
+        var phi_sRad = aspect
+          .updateMask(aspect.lte(180))
+          .unmask() 
+          .add(aspect_minus.unmask()) //add the minus values
+          .multiply(-1)   // make aspect uphill
+          .multiply(Math.PI / 180) // make it rad
+        
         // 2.1.3 Model geometry
         //reduce to 3 angle
         var phi_rRad = phi_iRad.subtract(phi_sRad)
@@ -108,7 +131,7 @@ var terrainCorrection = function(image, options) {
             var corrModel = _direct_model(theta_iRad, alpha_rRad, alpha_azRad)
 
         // apply model for Gamm0_f
-        var gamma0_flat = gamma0.select(['VV', 'VH']).divide(corrModel)
+        var gamma0_flat = gamma0.select(['VV', 'VH']).multiply(corrModel)
 
         // get Layover/Shadow mask
         var mask = _masking(alpha_rRad, theta_iRad, proj, buffer)


### PR DESCRIPTION
There was an error in the calculation of the aspect and heading angle, as the original implementation expects angles from -180 to 180, while we were using 0 to 360 
In addition, the aspect angle on EE seems downhill directed, while it should be uphill. 
All before calculating the radians. 

As a result, also the correction factor needs to be multiplied by gamma0 instead of being divided.