### PR TITLE
add oeel to the common python libs

### DIFF
--- a/modules/geospatial-toolkit/config/requirements.txt
+++ b/modules/geospatial-toolkit/config/requirements.txt
@@ -21,6 +21,7 @@ geeadd
 oauth2client
 google-api-python-client==1.12.8
 git+https://github.com/openforis/earthengine-api.git@v0.1.270#egg=earthengine-api&subdirectory=python
+oeel
 
 ########  BFAST dependencies ########
 wget


### PR DESCRIPTION
It will allow us to call JS recipes or other libs directly from Python with translating them to Python making everything way faster (application creation, interoperability etc...)

documentation can be found here: https://www.open-geocomputing.org/OpenEarthEngineLibrary/