### PR TITLE
drop some pins

### DIFF
--- a/modules/geospatial-toolkit/config/requirements.txt
+++ b/modules/geospatial-toolkit/config/requirements.txt
@@ -1,4 +1,4 @@
-# version 2021-09-13
+# version 2022-09-04
 ########  geospatial data analysis  ########
 scikit-image
 scipy
@@ -31,14 +31,14 @@ numpydoc
 git+https://github.com/12rambau/bfast.git
 
 ########  sepal modules  ########
-geemap==0.8.9
+geemap
 Unidecode
 pyperclip
 python-dateutil
 pytesmo
 Wand
 PyPDF2 # more recent version are avaiable (PyPDF4)
-rasterio==1.1.5
+rasterio
 openpyxl
 pre-commit
 


### PR DESCRIPTION
geemap was pinned as version > 0.8.9 was dependant to ipyleaflet > 0.13. as the pin on ipyleaflet is now removed we can use more advanced version of geemap. 
same goes for rasterio.

Fix #212. 

> **Note**
> @cdanielw, It needs to be deploy first on test as I need to check that this will not reinstall earthengine-api