### PR TITLE
build: related with #239.

### DIFF
--- a/modules/sandbox/script/init_jupyter.sh
+++ b/modules/sandbox/script/init_jupyter.sh
@@ -15,8 +15,8 @@ apt-get install -y libzmq3-dev
 R -e "pacman::p_load('IRkernel')"
 R -e "IRkernel::installspec(user = FALSE)"
 
-/usr/bin/python3 -m pip install ipywidgets
 /usr/bin/python3 -m pip install jupyterlab
+/usr/bin/python3 -m pip install ipywidgets==7.7.2 # https://github.com/voila-dashboards/voila/issues/1202#issuecomment-1255040572 until we wait.
 /usr/bin/python3 -m pip install jupyterlab-language-pack-fr-FR
 /usr/bin/python3 -m pip install jupyterlab-language-pack-es-ES
 /usr/bin/python3 -m pip install folium
@@ -40,6 +40,5 @@ npm install -g --unsafe-perm ijavascript
 npm install -g js-beautify
 /usr/bin/ijsinstall --install=global
 
-/usr/bin/python3 /usr/local/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager 
-/usr/bin/python3 /usr/local/bin/jupyter labextension install jupyter-leaflet
+
 /usr/bin/python3 /usr/local/bin/jupyter lab build


### PR DESCRIPTION
The latest release is causing a problem to render the widgets in `jupyterlab` as it was reported in #239 . Digging into the issue, some findings came up:

- When checking `jupyter labextension list` command, at the very bottom of the output, a message says that ` ...source extensions are overshadowed by older prebuilt extensions...` and it is referring to `jupyterlab widgets/manager`, it means that the extension has two different versions, a "_source extension_" and a "_prebuilt extension_", this is happening because [here](https://github.com/openforis/sepal/blob/bf9acdf32653b86aed6f52b1058b393209287ca5/modules/sandbox/script/init_jupyter.sh) we are installing `ipywidgets` using pip and later at the end we are adding the labextension install `@jupyter-widgets/jupyterlab-manager`.  

  This conflict started with newer ipywidgets versions that now depend on `jupyterlab_widgets` which after jupyter v.3 doesn't require anymore the [jupyter labextension installation](https://ipywidgets.readthedocs.io/en/stable/user_install.html#installing-in-jupyterlab-3-x), because they are are installing it automatically.

- Additionally, latest `ipywidgets>=8` doesn't support voila ([yet](https://github.com/voila-dashboards/voila/issues/1202#issuecomment-1255040572)) , so we have to install a previous version..

  When installing `ipywidgets 7.6.5` it will install (by mistake)` jypyterlab_widgets>2`, which is incompatible with ipywidgets<8, so, to overcome it, ipywidgets==7.7.2 has to be pinned to install jupyterlab_widgets<2.


In short:

- remove source extension installation due to overshaded problem
- set ipywidgets<8 due to incompatibility with voila.

I've tested it in a different environment, so it would be nice if we can build on test to check if it works.