### PR TITLE
fix: install the holy trinity in every venv

### DIFF
--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -66,6 +66,9 @@ function update_venv {
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip ipykernel wheel >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip --upgrade pip >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install -r "$app_path"/requirements.txt -U --no-cache-dir >> "$venv_log_file"
+        "$venv_path"/bin/python3 -m pip install gdal==3.4.3 -U --no-cache-dir >> "$venv_log_file"
+        "$venv_path"/bin/python3 -m pip install pyproj==3.4.1 -U --no-cache-dir >> "$venv_log_file"
+        "$venv_path"/bin/python3 -m pip install "git+https://github.com/openforis/earthengine-api.git@v0.1.270#egg=earthengine-api&subdirectory=python" -U --no-cache-dir >> "$venv_log_file"
         # "$venv_path"/bin/python3 -m pip install -r "$app_path"/requirements.txt -U --cache-dir /root/.cache/pip >> "$venv_log_file"
         if [[ -d $current_venv_path ]] 
         then


### PR DESCRIPTION
The idea is to install the triptic gdal/proj/earthengine-api for every venv directly from the script. Here are the few scenario I thought about that should be working: 
- the requirements.txt have sanitized version: you'll get a "requirement already met" and nothing changes
- SEPAL version of GDAL changes (or any of the 3), we change it in this file as well and whatever the requirements was specifying it will be working in our env
- the dev wwas lazy and didn't pinned versions, at least these 3 one will be set to correct versions
- I work in another env and cannot use the same version (I have a different version of python), It ensures that I can use looser pins without crashing SEPAL env

side effect: I think it Fixes #258  as gdal will be installed after numpy (which should be in the requirements.txt)

For the version I picked: 
- the latest fork of earthengine: https://github.com/openforis/earthengine-api/releases/tag/v0.1.332
- the installed version of gdal: https://github.com/openforis/sepal/blob/f7563d4242eec115df5ab97453f872735d8bc92a/modules/sandbox-base/Dockerfile#L82
- a version of pyproj compatible with our proj parameter: https://github.com/openforis/sepal/blob/f7563d4242eec115df5ab97453f872735d8bc92a/modules/sandbox-base/Dockerfile#L83 see in this table https://pyproj4.github.io/pyproj/stable/installation.html#installing-from-source