### PR TITLE
fix: reorder installation of python libs 

### DIFF
--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -65,11 +65,11 @@ function update_venv {
         python3 -m venv $venv_path
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip ipykernel wheel >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip --upgrade pip >> "$venv_log_file"
-        "$venv_path"/bin/python3 -m pip install -r "$app_path"/requirements.txt -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install numpy -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install gdal==3.4.3 -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install pyproj==3.4.1 -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install "git+https://github.com/openforis/earthengine-api.git@v0.1.343#egg=earthengine-api&subdirectory=python" -U --no-cache-dir >> "$venv_log_file"
+        "$venv_path"/bin/python3 -m pip install -r "$app_path"/requirements.txt -U --no-cache-dir >> "$venv_log_file"
         if [[ -d $current_venv_path ]] 
         then
             echo "Moving away current venv: $current_venv_path" >> "$venv_log_file"

--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -66,6 +66,7 @@ function update_venv {
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip ipykernel wheel >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install --cache-dir /root/.cache/pip --upgrade pip >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install -r "$app_path"/requirements.txt -U --no-cache-dir >> "$venv_log_file"
+        "$venv_path"/bin/python3 -m pip install numpy -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install gdal==3.4.3 -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install pyproj==3.4.1 -U --no-cache-dir >> "$venv_log_file"
         "$venv_path"/bin/python3 -m pip install "git+https://github.com/openforis/earthengine-api.git@v0.1.343#egg=earthengine-api&subdirectory=python" -U --no-cache-dir >> "$venv_log_file"


### PR DESCRIPTION
- install numpy before gdal as it compulsory to have access to GDAL_ARRAY
- install pyproj, gdal and gee fork before the requirements: 
  we do that to avoid issues with loose requirements or worse sub-requirements (e.g. localtileserver need gdal to be installed before)
  requirements.txt can remain as loose as necessary for local build and remain compatible with SEPAL