### PR TITLE
feat: install sidecar for every users

### DIFF
--- a/modules/sandbox/script/init_jupyter.sh
+++ b/modules/sandbox/script/init_jupyter.sh
@@ -23,6 +23,7 @@ R -e "IRkernel::installspec(user = FALSE)"
 /usr/bin/python3 -m pip install ipyleaflet
 /usr/bin/python3 -m pip install ipyvuetify
 /usr/bin/python3 -m pip install lckr-jupyterlab-variableinspector
+/usr/bin/python3 -m pip install sidecar
 
 git clone https://github.com/ipython-contrib/jupyter_contrib_nbextensions.git
 /usr/bin/python3 -m pip install jupyter_latex_envs # Required for jupyter_contrib_nbextensions


### PR DESCRIPTION
I started using it for myself and I simply don't use the GEE code editor anymore. 
everyone: "But Pierrick what are you talking about ?"
pierrick: "The holy sidecar"

What is bugging me with the GEE code editor is that I'm forced to relaunch everything every time I make a modification even if it's an addition. On the other hand, having a live map and a value inspector is great and allow me to make fantastic experiments.

But I also love the  earthengine python API as it grant me access to open-source tools (geemap, gee_tools etc....) and tools from non-gee sources (rasterio, geopandas etc...). 

These 2 worlds were pretty much irreconcilable.

Soooo ...... Behold the sidecar: 

<img width="1920" alt="sidecar_with_data" src="https://github.com/openforis/sepal/assets/12596392/4dba8c78-4cd7-46f4-8dcb-3e818e3bff5d">

It's a built-in jupyter tool that allows you to display any widget in a side view without losing the connection to the notebook. I guess you see me coming, I've decided to display a SepalMap. and now I have a fully functional, responsive map that instead of being lost at the start or end of my notebook, will consistently remain next to my code. In addition, this map will update itself upon cell execution and not reload all the layer. Isn't it cool? 

If you like the feature I created this small PR to add the lib for all users and this documentation page to explain a bit how it works: 
- PR: https://github.com/openforis/sepal-doc/pull/411
- pre-build: https://sepal-doc--411.org.readthedocs.build/en/411/cli/gee.html#use-google-earth-engine-in-the-jupyter-interface

tagging some people that may be interested: 
@dfguerrerom, @cdanielw, @BuddyVolly, @eriklindquist, @lecrabe 
