### PR TITLE
avoid duplicated project names

### DIFF
--- a/modules/gui/src/app/home/body/process/recipeList/project.js
+++ b/modules/gui/src/app/home/body/process/recipeList/project.js
@@ -12,14 +12,17 @@ import styles from './project.module.css'
 
 const fields = {
     name: new Form.Field()
-        .notBlank('project.form.name.required')
+        .notBlank('process.project.form.name.required')
+        .predicate((name, {projectNames}) => !projectNames.includes(name.toLowerCase()), 'process.project.form.name.unique')
 }
+
 const mapStateToProps = (state, ownProps) => {
     const project = ownProps.project
     return {
         values: {
             id: project && project.id,
-            name: (project && project.name) || ''
+            name: (project && project.name) || '',
+            projectNames: ownProps.projectNames
         }
     }
 }
@@ -71,6 +74,7 @@ export const Project = compose(
 
 Project.propTypes = {
     project: PropTypes.object.isRequired,
+    projectNames: PropTypes.array.isRequired,
     onApply: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired
 }

--- a/modules/gui/src/app/home/body/process/recipeList/project.js
+++ b/modules/gui/src/app/home/body/process/recipeList/project.js
@@ -18,11 +18,12 @@ const fields = {
 
 const mapStateToProps = (state, ownProps) => {
     const project = ownProps.project
+    const projectNames = ownProps.projectNames
     return {
         values: {
             id: project && project.id,
             name: (project && project.name) || '',
-            projectNames: ownProps.projectNames
+            projectNames: projectNames
         }
     }
 }

--- a/modules/gui/src/app/home/body/process/recipeList/projects.js
+++ b/modules/gui/src/app/home/body/process/recipeList/projects.js
@@ -91,21 +91,11 @@ class _Projects extends React.Component {
     renderProjects() {
         const {projects} = this.props
 
-        // Helper function to check for duplicate names
-        const isDuplicate = (project, index, projects) => {
-            return projects.some((p, i) => p.name === project.name && i !== index)
-        }
-
         if (projects.length) {
             return (
                 <Layout type='vertical' spacing='tight'>
-                    {projects.map((project, index) => {
-                        const duplicate = isDuplicate(project, index, projects)
-                        const displayName = duplicate ? `${project.name}_${project.id.slice(0, 3)}` : project.name
-                        return this.renderProject({...project, name: displayName}, index)
-                    })}
+                    {projects.map((project, index) => this.renderProject(project, index))}
                 </Layout>
-
             )
         } else {
             return (
@@ -129,6 +119,7 @@ class _Projects extends React.Component {
                 onClick={() => this.selectProject(project.id)}>
                 <CrudItem
                     title={project.name}
+                    description={msg('process.project.description', {count: projectRecipes.length})}
                     editTooltip={msg('process.project.edit.tooltip')}
                     removeTooltip={msg('process.project.remove.tooltip')}
                     removeTitle={msg('process.project.remove.title')}
@@ -183,10 +174,11 @@ class _Projects extends React.Component {
     }
 
     renderProjectPanel(project) {
+        const projectNames = this.props.projects.map(({name}) => name)
         return (
             <Project
                 project={project}
-                projectNames={this.props.projects.map(({name}) => name)}
+                projectNames={projectNames}
                 onApply={project => this.updateProject(project)}
                 onCancel={() => this.editProject()}
             />

--- a/modules/gui/src/app/home/body/process/recipeList/projects.js
+++ b/modules/gui/src/app/home/body/process/recipeList/projects.js
@@ -90,11 +90,22 @@ class _Projects extends React.Component {
 
     renderProjects() {
         const {projects} = this.props
+
+        // Helper function to check for duplicate names
+        const isDuplicate = (project, index, projects) => {
+            return projects.some((p, i) => p.name === project.name && i !== index)
+        }
+
         if (projects.length) {
             return (
                 <Layout type='vertical' spacing='tight'>
-                    {projects.map((project, index) => this.renderProject(project, index))}
+                    {projects.map((project, index) => {
+                        const duplicate = isDuplicate(project, index, projects)
+                        const displayName = duplicate ? `${project.name}_${project.id.slice(0, 3)}` : project.name
+                        return this.renderProject({...project, name: displayName}, index)
+                    })}
                 </Layout>
+
             )
         } else {
             return (
@@ -175,6 +186,7 @@ class _Projects extends React.Component {
         return (
             <Project
                 project={project}
+                projectNames={this.props.projects.map(({name}) => name)}
                 onApply={project => this.updateProject(project)}
                 onCancel={() => this.editProject()}
             />

--- a/modules/gui/src/app/home/body/process/recipeList/recipeList.js
+++ b/modules/gui/src/app/home/body/process/recipeList/recipeList.js
@@ -296,7 +296,7 @@ class _RecipeList extends React.Component {
                     timestamp={recipe.updateTime}
                     highlight={this.getHighlightMatcher()}
                     highlightTitle={false}
-                    duplicateTooltip={msg('procthis.getHighlightMatcher()ess.menu.duplicateRecipe.tooltip')}
+                    duplicateTooltip={msg('process.menu.duplicateRecipe.tooltip')}
                     removeTooltip={msg('process.menu.removeRecipe.tooltip')}
                     selectTooltip={msg('process.menu.selectRecipe.tooltip')}
                     selected={edit ? this.isSelected(recipe.id) : undefined}

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -4131,7 +4131,9 @@
         "project": {
             "title": "Project",
             "form": {
-                "name.label": "Name"
+                "name.label": "Name",
+                "name.required" : "Name is required",
+                "name.unique" : "Project name is already in use"
             },
             "edit": {
                 "tooltip": "Edit project"

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -4130,6 +4130,7 @@
         },
         "project": {
             "title": "Project",
+            "description": "{count} {count, plural, one {recipe} other {recipes}}",
             "form": {
                 "name.label": "Name",
                 "name.required" : "Name is required",


### PR DESCRIPTION
This PR aims to close https://github.com/openforis/sepal/issues/320.

- I have added a `predicate` to the name field that validates the uniqueness of the input name, using as reference the `projectNames` property.t
- If there's already a duplicated name in `projects` component, it will add part of its id to the name.

@lpaolini , could you please check this PR and do any suggestions?