### PR TITLE
validate duplicated project names

### DIFF
--- a/modules/gui/src/app/home/body/process/recipeList/project.jsx
+++ b/modules/gui/src/app/home/body/process/recipeList/project.jsx
@@ -12,14 +12,18 @@ import styles from './project.module.css'
 
 const fields = {
     name: new Form.Field()
-        .notBlank('project.form.name.required')
+        .notBlank('process.project.form.name.required')
+        .predicate((name, {projectNames}) => !projectNames.includes(name.toLowerCase()), 'process.project.form.name.unique')
 }
+
 const mapStateToProps = (state, ownProps) => {
     const project = ownProps.project
+    const projectNames = ownProps.projectNames
     return {
         values: {
             id: project && project.id,
-            name: (project && project.name) || ''
+            name: (project && project.name) || '',
+            projectNames: projectNames
         }
     }
 }
@@ -71,6 +75,7 @@ export const Project = compose(
 
 Project.propTypes = {
     project: PropTypes.object.isRequired,
+    projectNames: PropTypes.array.isRequired,
     onApply: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired
 }

--- a/modules/gui/src/app/home/body/process/recipeList/projects.jsx
+++ b/modules/gui/src/app/home/body/process/recipeList/projects.jsx
@@ -118,6 +118,7 @@ class _Projects extends React.Component {
                 onClick={() => this.selectProject(project.id)}>
                 <CrudItem
                     title={project.name}
+                    description={msg('process.project.description', {count: projectRecipes.length})}
                     editTooltip={msg('process.project.edit.tooltip')}
                     removeTooltip={msg('process.project.remove.tooltip')}
                     removeTitle={msg('process.project.remove.title')}
@@ -172,9 +173,11 @@ class _Projects extends React.Component {
     }
 
     renderProjectPanel(project) {
+        const projectNames = this.props.projects.map(({name}) => name)
         return (
             <Project
                 project={project}
+                projectNames={projectNames}
                 onApply={project => this.updateProject(project)}
                 onCancel={() => this.editProject()}
             />

--- a/modules/gui/src/app/home/body/process/recipeList/recipeList.jsx
+++ b/modules/gui/src/app/home/body/process/recipeList/recipeList.jsx
@@ -296,7 +296,7 @@ class _RecipeList extends React.Component {
                     timestamp={recipe.updateTime}
                     highlight={this.getHighlightMatcher()}
                     highlightTitle={false}
-                    duplicateTooltip={msg('procthis.getHighlightMatcher()ess.menu.duplicateRecipe.tooltip')}
+                    duplicateTooltip={msg('process.menu.duplicateRecipe.tooltip')}
                     removeTooltip={msg('process.menu.removeRecipe.tooltip')}
                     selectTooltip={msg('process.menu.selectRecipe.tooltip')}
                     selected={edit ? this.isSelected(recipe.id) : undefined}

--- a/modules/gui/src/app/home/body/process/recipeList/recipeList.jsx
+++ b/modules/gui/src/app/home/body/process/recipeList/recipeList.jsx
@@ -158,6 +158,7 @@ class _RecipeList extends React.Component {
 
     toggleEdit() {
         this.setState(({edit}) => ({edit: !edit}))
+        this.unselectAll()
     }
 
     renderSelectButton() {
@@ -422,6 +423,10 @@ class _RecipeList extends React.Component {
             ? _.difference(prevSelectedIds, filteredSelectedIds)
             : [...prevSelectedIds, ...filteredIds]
         this.setSelectedIds(selectedIds)
+    }
+
+    unselectAll() {
+        this.setSelectedIds([])
     }
 
     moveSelected(projectId) {

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -4130,8 +4130,11 @@
         },
         "project": {
             "title": "Project",
+            "description": "{count} {count, plural, one {recipe} other {recipes}}",
             "form": {
-                "name.label": "Name"
+                "name.label": "Name",
+                "name.required" : "Name is required",
+                "name.unique" : "Project name is already in use"
             },
             "edit": {
                 "tooltip": "Edit project"


### PR DESCRIPTION
This PR overrides https://github.com/openforis/sepal/pull/326 and aims to close https://github.com/openforis/sepal/issues/320.

- Add a predicate to the name field that validates the uniqueness of the input name, using as reference the projectNames property.
- Add the number of recipes contained in each of the projects as `CrudItem.description`
- Also fixed a couple of keys.
- Unselect previous selected recipes after `edit` (?)

@lpaolini, this PR has `vite` branch as base, as you suggested. Please let me know if there's anything else I need to change. 

![image](https://github.com/user-attachments/assets/80b9c436-d9c6-4c22-bc2c-6427ebd3d495)
