### PR TITLE
Added kernel disposal for Voila/Jupyter apps on unmount

### DIFF
--- a/modules/gui/src/app/home/body/apps/appInstance.jsx
+++ b/modules/gui/src/app/home/body/apps/appInstance.jsx
@@ -29,7 +29,6 @@ class _AppInstance extends React.Component {
     constructor(props) {
         super(props)
         this.iFrameLoaded = this.iFrameLoaded.bind(this)
-        this.disposeVoilaKernel = this.disposeVoilaKernel.bind(this)
     }
 
     render() {
@@ -136,13 +135,10 @@ class _AppInstance extends React.Component {
     }
 
     componentWillUnmount() {
-        // Dispose kernel for Voila/Jupyter apps (apps that use srcDoc)
-        if (!this.useIFrameSrc()) {
-            this.disposeVoilaKernel()
-        }
+        this.unloadIFrame()
     }
 
-    disposeVoilaKernel() {
+    unloadIFrame() {
         const iFrame = this.iFrameRef.current
         if (!iFrame?.contentWindow) {
             return

--- a/modules/gui/src/app/home/body/apps/appInstance.jsx
+++ b/modules/gui/src/app/home/body/apps/appInstance.jsx
@@ -29,6 +29,7 @@ class _AppInstance extends React.Component {
     constructor(props) {
         super(props)
         this.iFrameLoaded = this.iFrameLoaded.bind(this)
+        this.disposeVoilaKernel = this.disposeVoilaKernel.bind(this)
     }
 
     render() {
@@ -131,6 +132,25 @@ class _AppInstance extends React.Component {
         if (this.useIFrameSrc() && src) {
             busy.set(id, false)
             this.setState({appState: 'READY'})
+        }
+    }
+
+    componentWillUnmount() {
+        // Dispose kernel for Voila/Jupyter apps (apps that use srcDoc)
+        if (!this.useIFrameSrc()) {
+            this.disposeVoilaKernel()
+        }
+    }
+
+    disposeVoilaKernel() {
+        const iFrame = this.iFrameRef.current
+        if (!iFrame?.contentWindow) {
+            return
+        }
+        try {
+            iFrame.contentWindow.dispatchEvent(new Event('beforeunload'))
+        } catch (_error) {
+            // iframe may already be destroyed
         }
     }
 


### PR DESCRIPTION
Added componentWillUnmount lifecycle method to dispatch beforeunload event to Voila/Jupyter app iframes when closing, ensuring proper kernel cleanup and resource release.

aims to close #336 