### PR TITLE
Render docker apps via iframe src so multi-route bundles work

### DIFF
--- a/modules/gui/src/app/home/body/apps/appInstance.jsx
+++ b/modules/gui/src/app/home/body/apps/appInstance.jsx
@@ -83,7 +83,6 @@ class _AppInstance extends React.Component {
         const {app: {id, endpoint, path}, tab: {busy}, stream} = this.props
         if (endpoint === 'docker') {
             busy.set(id, true)
-            this.setState({appState: 'INITIALIZED'})
             publishEvent('launch_app', {app: id})
             stream('RUN_APP',
                 get$(`${path}`, {
@@ -92,7 +91,7 @@ class _AppInstance extends React.Component {
                         maxRetries: 9
                     }
                 }).pipe(
-                    map(srcDoc => ({srcDoc}))
+                    map(() => ({appState: 'INITIALIZED', src: path}))
                 ),
                 result => this.setState(result),
                 error => this.onError(error)
@@ -122,7 +121,7 @@ class _AppInstance extends React.Component {
 
     useIFrameSrc() {
         const {app: {endpoint}} = this.props
-        return !endpoint || ['rstudio', 'shiny'].includes(endpoint)
+        return !endpoint || ['rstudio', 'shiny', 'docker'].includes(endpoint)
     }
 
     iFrameLoaded() {


### PR DESCRIPTION
For docker apps, the GUI was fetching the HTML and writing it into the iframe via `srcDoc`. That left `window.location` at `about:srcdoc`, hiding the URL from the inner SPA — fine for single-route apps, broken for multi-route Solara bundles which read `window.location` to dispatch routes.

Switches docker apps to set `iframe.src = path` after the warmup GET. The iframe now reflects the real URL so the inner SPA renders the correct child route.