### PR TITLE
Pinned PROJ/GDAL data dirs for conda kernels

### DIFF
--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -38,14 +38,56 @@ function clone {
     git fetch
 }
 
+function json_escape {
+    local value=$1
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
 function create_kernel_json {
     echo "Creating kernel: $kernel_path"
-    mkdir -p $kernel_path
-    local env_entries="\"PYTHONNOUSERSITE\": \"1\""
-    if [[ -f "$app_path/sepal_environment.yml" ]]; then
-        env_entries="$env_entries, \"PROJ_LIB\": \"$venv_path/share/proj\", \"PROJ_DATA\": \"$venv_path/share/proj\", \"GDAL_DATA\": \"$venv_path/share/gdal\""
-    fi
-    echo "{\"argv\": [\"$venv_path/bin/python3\", \"-m\", \"ipykernel_launcher\", \"-f\", \"{connection_file}\"], \"display_name\": \" (venv) $app_label\", \"language\": \"python\", \"env\": {$env_entries}}" > "$kernel_path/kernel.json"
+    mkdir -p "$kernel_path"
+    local python_bin=$(json_escape "$venv_path/bin/python3")
+    local display_name=$(json_escape " (venv) $app_label")
+    local proj_data=$(json_escape "$venv_path/share/proj")
+    local gdal_data=$(json_escape "$venv_path/share/gdal")
+    {
+        cat <<EOF
+{
+  "argv": [
+    "$python_bin",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "$display_name",
+  "language": "python",
+EOF
+        if [[ -f "$app_path/sepal_environment.yml" ]]; then
+            cat <<EOF
+  "env": {
+    "PYTHONNOUSERSITE": "1",
+    "PROJ_LIB": "$proj_data",
+    "PROJ_DATA": "$proj_data",
+    "GDAL_DATA": "$gdal_data"
+  }
+EOF
+        else
+            cat <<EOF
+  "env": {
+    "PYTHONNOUSERSITE": "1"
+  }
+EOF
+        fi
+        cat <<EOF
+}
+EOF
+    } > "$kernel_path/kernel.json"
 }
 
 function update_kernel {

--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -85,6 +85,7 @@ function update_venv {
             echo "Moving away current venv: $current_venv_path" >> "$venv_log_file"
             mv -f "$current_venv_path" "$work_kernels"/venv-to-remove >> "$venv_log_file"
         fi
+        mkdir -p "$kernel_path" >> "$venv_log_file"
         echo "Moving new venv into place: "$venv_path" -> $current_venv_path" >> "$venv_log_file"
         mv -f "$venv_path" "$current_venv_path" >> "$venv_log_file"
         echo "Setting venv file permissions: $current_venv_path" >> "$venv_log_file"

--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -38,19 +38,17 @@ function clone {
     git fetch
 }
 
-function create_kernel {
+function create_kernel_json {
     echo "Creating kernel: $kernel_path"
     mkdir -p $kernel_path
-    echo "{\"argv\": [\"$venv_path/bin/python3\", \"-m\", \"ipykernel_launcher\", \"-f\", \"{connection_file}\"], \"display_name\": \" (venv) $app_label\", \"language\": \"python\"}" > "$kernel_path/kernel.json"
+    local env_entries="\"PYTHONNOUSERSITE\": \"1\""
+    if [[ -f "$app_path/sepal_environment.yml" ]]; then
+        env_entries="$env_entries, \"PROJ_LIB\": \"$venv_path/share/proj\", \"PROJ_DATA\": \"$venv_path/share/proj\", \"GDAL_DATA\": \"$venv_path/share/gdal\""
+    fi
+    echo "{\"argv\": [\"$venv_path/bin/python3\", \"-m\", \"ipykernel_launcher\", \"-f\", \"{connection_file}\"], \"display_name\": \" (venv) $app_label\", \"language\": \"python\", \"env\": {$env_entries}}" > "$kernel_path/kernel.json"
 }
 
 function update_kernel {
-    if [[ ! -d "$kernel_path" ]]
-    then
-        create_kernel
-    else
-        echo "Have an existing kernel: $kernel_path"
-    fi
     update_venv
 }
 
@@ -94,6 +92,7 @@ function update_venv {
         echo "Removing old venv" >> "$venv_log_file"
         rm -rf "$work_kernels"/venv-to-remove >> "$venv_log_file"
         touch $current_venv_path/.installed >> "$venv_log_file"
+        create_kernel_json >> "$venv_log_file"
         echo "Completed venv update: $current_venv_path" >> "$venv_log_file"
     else
         echo "Requirements not modified since last build: $app_path"


### PR DESCRIPTION
Fixes `CRSError: proj.db contains DATABASE.LAYOUT.VERSION.MINOR = 3 whereas a number >= 6 is expected` in conda-based app kernels.

The container exports `PROJ_LIB=/usr/share/proj` and `GDAL_DATA=/usr/share/gdal` globally, forcing the env's newer libproj/libgdal (from conda-forge) to read the system `proj.db`. The generated `kernel.json` now sets `PROJ_LIB`, `PROJ_DATA` and `GDAL_DATA` to the env's own `share/proj` and `share/gdal` for `sepal_environment.yml` apps. `PYTHONNOUSERSITE=1` is set on all kernels.

`create_kernel` was renamed to `create_kernel_json` and is now called from `update_venv` only when the env is rebuilt — existing kernels pick up the new env block on the next requirements change, and idle polls don't touch `kernel.json`.