### PR TITLE
Consume sepal-apps-catalog from app-manager and app-launcher

### DIFF
--- a/modules/app-launcher/docker-compose.yml
+++ b/modules/app-launcher/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       EE_PRIVATE_KEY: "${EE_PRIVATE_KEY}"
       EE_CREDENTIALS_PATH: "${SEPAL_DATA_DIR}/app-launcher/service-account-credentials.json"
       GOOGLE_PROJECT_ID: "${GOOGLE_PROJECT_ID}"
+      SEPAL_APPS_CATALOG_URL: "${SEPAL_APPS_CATALOG_URL:-}"
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "80"]
       start_period: 60s

--- a/modules/app-launcher/src/apiService.js
+++ b/modules/app-launcher/src/apiService.js
@@ -17,6 +17,16 @@ const fetchAppsFromApi$ = () => {
     )
 }
 
+const fetchCatalog$ = url =>
+    get$(url).pipe(
+        map(response => JSON.parse(response.body)),
+        catchError(error => {
+            log.error(`Failed to fetch apps catalog from ${url}:`, error)
+            return EMPTY
+        })
+    )
+
 module.exports = {
-    fetchAppsFromApi$
+    fetchAppsFromApi$,
+    fetchCatalog$
 }

--- a/modules/app-launcher/src/apps.js
+++ b/modules/app-launcher/src/apps.js
@@ -3,8 +3,9 @@ const log = require('#sepal/log').getLogger('apps')
 const {basename} = require('path')
 const {cloneOrPull} = require('./git')
 const {buildAndRestart, startContainer, isContainerRunning} = require('./docker')
-const {fetchAppsFromApi$} = require('./apiService')
+const {fetchAppsFromApi$, fetchCatalog$} = require('./apiService')
 const {refreshProxyEndpoints} = require('./proxyManager')
+const {appsCatalogUrl} = require('./config')
 
 const UPDATE_DELAY_SECONDS = 30
 
@@ -17,12 +18,16 @@ const monitorApps = () =>
         complete: () => log.fatal('Monitor unexpectedly completed')
     })
 
+const source$ = () => appsCatalogUrl
+    ? fetchCatalog$(appsCatalogUrl)
+    : fetchAppsFromApi$()
+
 const apps$ = () =>
-    fetchAppsFromApi$().pipe(
+    source$().pipe(
         switchMap(({apps}) => from(apps)),
         filter(({repository}) => repository),
         filter(({endpoint}) => endpoint === 'docker'),
-        map(({endpoint, label, repository, branch}) => {
+        map(({endpoint, label, repository, branch, commit}) => {
             const name = basename(repository).replace(/\.git$/, '')
             return {
                 endpoint,
@@ -30,7 +35,8 @@ const apps$ = () =>
                 label,
                 path: `/var/lib/sepal/app-launcher/apps/${name}`,
                 repository,
-                branch
+                branch,
+                commit: commit || null
             }
         }),
         catchError(error => {
@@ -39,8 +45,8 @@ const apps$ = () =>
         })
     )
 
-const updateApp$ = ({path, repository, branch, name}) =>
-    from(cloneOrPull({path, repository, branch})).pipe(
+const updateApp$ = ({path, repository, branch, commit, name}) =>
+    from(cloneOrPull({path, repository, branch, commit})).pipe(
         switchMap(({action}) => {
             log.info(`Git operation completed: ${action}`)
             if (action === 'cloned' || action === 'updated') {
@@ -76,4 +82,4 @@ const refreshProxies = () => {
     )
 }
 
-module.exports = {monitorApps}
+module.exports = {monitorApps, apps$, source$}

--- a/modules/app-launcher/src/config.js
+++ b/modules/app-launcher/src/config.js
@@ -64,6 +64,10 @@ try {
             new Option('--deploy-environment <value>')
                 .env('DEPLOY_ENVIRONMENT')
         )
+        .addOption(
+            new Option('--apps-catalog-url <value>')
+                .env('SEPAL_APPS_CATALOG_URL')
+        )
         .parse()
 } catch (error) {
     fatalError(error)
@@ -79,7 +83,8 @@ const {
     geeEmail,
     geeKey,
     googleProjectId,
-    deployEnvironment
+    deployEnvironment,
+    appsCatalogUrl
 } = program.opts()
 
 log.info('Configuration loaded')
@@ -94,5 +99,6 @@ module.exports = {
     geeEmail,
     geeKey,
     googleProjectId,
-    deployEnvironment
+    deployEnvironment,
+    appsCatalogUrl: appsCatalogUrl || null
 }

--- a/modules/app-launcher/src/git.js
+++ b/modules/app-launcher/src/git.js
@@ -83,11 +83,26 @@ const getRepoInfo = async appPath => {
     const {stdout: originUrlRaw} = await executeCommand(
         'git', ['config', '--get', 'remote.origin.url'], {cwd: appPath}
     )
-    const {stdout: branchName} = await executeCommand(
+    const {stdout: rawBranch} = await executeCommand(
         'git', ['rev-parse', '--abbrev-ref', 'HEAD'], {cwd: appPath}
     )
     const originUrl = originUrlRaw.trim()
-  
+    const detached = rawBranch.trim() === 'HEAD'
+
+    let branch = rawBranch.trim()
+    if (detached) {
+        try {
+            const {stdout: containing} = await executeCommand(
+                'git', ['for-each-ref', '--points-at', 'HEAD', '--format=%(refname:short)', 'refs/remotes/origin'],
+                {cwd: appPath}
+            )
+            const ref = containing.split('\n').map(s => s.trim()).find(Boolean)
+            if (ref) branch = ref.replace(/^origin\//, '')
+        } catch (_e) {
+            // leave branch as 'HEAD'
+        }
+    }
+
     let commitUrl = null
     if (originUrl.includes('github.com')) {
         let repoUrl = originUrl
@@ -97,13 +112,15 @@ const getRepoInfo = async appPath => {
     }
 
     let updateAvailable = false
-    try {
-        await executeCommand('git', ['remote', 'update'], {cwd: appPath})
-        const {stdout: local} = await executeCommand('git', ['rev-parse', 'HEAD'], {cwd: appPath})
-        const {stdout: remote} = await executeCommand('git', ['rev-parse', '@{u}'], {cwd: appPath})
-        updateAvailable = local.trim() !== remote.trim()
-    } catch (warnErr) {
-        log.warn(`Could not check remote updates: ${warnErr.message}`)
+    if (!detached) {
+        try {
+            await executeCommand('git', ['remote', 'update'], {cwd: appPath})
+            const {stdout: local} = await executeCommand('git', ['rev-parse', 'HEAD'], {cwd: appPath})
+            const {stdout: remote} = await executeCommand('git', ['rev-parse', '@{u}'], {cwd: appPath})
+            updateAvailable = local.trim() !== remote.trim()
+        } catch (warnErr) {
+            log.warn(`Could not check remote updates: ${warnErr.message}`)
+        }
     }
 
     const appInfo = {
@@ -111,7 +128,7 @@ const getRepoInfo = async appPath => {
         lastCommitId: commitId.trim(),
         url: originUrl,
         commitUrl,
-        branch: branchName.trim(),
+        branch,
         updateAvailable
     }
 
@@ -121,17 +138,41 @@ const getRepoInfo = async appPath => {
 
 }
 
-const cloneOrPull = async ({path: appPath, repository, branch}) => {
+const checkoutCommit = async (appPath, branch, commit) => {
+    log.info(`Pinning repository at ${appPath} to commit ${commit}`)
+    try {
+        await executeCommand('git', ['fetch', 'origin', branch], {cwd: appPath})
+        await executeCommand('git', ['checkout', '--detach', commit], {cwd: appPath})
+    } catch (err) {
+        log.error(`Failed to checkout commit '${commit}': ${err.message}`)
+        throw new ClientException(`Failed to checkout commit '${commit}': ${err.message}`)
+    }
+}
+
+const cloneOrPull = async ({path: appPath, repository, branch, commit}) => {
     try {
         const exists = await pathExists(appPath)
         if (!exists) {
             log.info(`Path '${appPath}' not found → cloning`)
             await cloneRepository(repository, branch, appPath)
-            await checkoutBranch(appPath, branch)
+            if (commit) {
+                await checkoutCommit(appPath, branch, commit)
+            } else {
+                await checkoutBranch(appPath, branch)
+            }
             return {action: 'cloned', success: true}
         }
+        if (commit) {
+            const current = await getCurrentCommitHash(appPath)
+            if (current === commit) {
+                log.info(`No update needed for ${appPath}: already at ${commit}`)
+                return {action: 'none', success: true}
+            }
+            await checkoutCommit(appPath, branch, commit)
+            return {action: 'updated', success: true}
+        }
         return await pullUpdates(appPath, branch)
-        
+
     } catch (err) {
         log.error(`Error in cloneOrPull: ${err.message}`)
         if (err.statusCode === 500) {

--- a/modules/app-launcher/src/git.js
+++ b/modules/app-launcher/src/git.js
@@ -91,15 +91,16 @@ const getRepoInfo = async appPath => {
 
     let branch = rawBranch.trim()
     if (detached) {
+        branch = commitId.trim().slice(0, 7)
         try {
             const {stdout: containing} = await executeCommand(
-                'git', ['for-each-ref', '--points-at', 'HEAD', '--format=%(refname:short)', 'refs/remotes/origin'],
+                'git', ['for-each-ref', '--points-at', 'HEAD', '--format=%(refname:short)', 'refs/remotes/origin', 'refs/tags'],
                 {cwd: appPath}
             )
             const ref = containing.split('\n').map(s => s.trim()).find(Boolean)
             if (ref) branch = ref.replace(/^origin\//, '')
         } catch (_e) {
-            // leave branch as 'HEAD'
+            // keep short SHA fallback
         }
     }
 

--- a/modules/app-launcher/src/proxy.js
+++ b/modules/app-launcher/src/proxy.js
@@ -4,12 +4,12 @@ const url = require('url')
 const {isMatch} = require('micromatch')
 const {getRequestUser, setRequestUser} = require('./user')
 const {usernameTag, urlTag} = require('./tag')
-const {fetchAppsFromApi$} = require('./apiService')
+const {source$} = require('./apps')
 const {sepalHost} = require('./config')
 
 const log = require('#sepal/log').getLogger('proxy')
 
-const proxyEndpoints$ = expressApp => fetchAppsFromApi$().pipe(
+const proxyEndpoints$ = expressApp => source$().pipe(
     switchMap(({apps}) => from(apps)),
     filter(({repository}) => repository),
     filter(({endpoint}) => endpoint === 'docker'),

--- a/modules/app-manager/docker-compose.yml
+++ b/modules/app-manager/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "${SEPAL_DATA_DIR}/app-manager/images:/var/lib/sepal/app-manager/images"
     environment:
       DEPLOY_ENVIRONMENT: "${DEPLOY_ENVIRONMENT}"
+      SEPAL_APPS_CATALOG_URL: "${SEPAL_APPS_CATALOG_URL:-}"
     networks:
       - sepal
     healthcheck:

--- a/modules/app-manager/src/apiService.js
+++ b/modules/app-manager/src/apiService.js
@@ -1,0 +1,14 @@
+const {EMPTY, catchError, map} = require('rxjs')
+const {get$} = require('#sepal/httpClient')
+const log = require('#sepal/log').getLogger('apiService')
+
+const fetchCatalog$ = url =>
+    get$(url).pipe(
+        map(response => JSON.parse(response.body)),
+        catchError(error => {
+            log.error(`Failed to fetch apps catalog from ${url}:`, error)
+            return EMPTY
+        })
+    )
+
+module.exports = {fetchCatalog$}

--- a/modules/app-manager/src/apps.js
+++ b/modules/app-manager/src/apps.js
@@ -1,8 +1,14 @@
-const {EMPTY, from, interval, catchError, delay, exhaustMap, filter, map, concatMap, switchMap} = require('rxjs')
+const {EMPTY, defer, from, interval, catchError, defaultIfEmpty, delay, exhaustMap, filter, map, concatMap, switchMap, of} = require('rxjs')
 const log = require('#sepal/log').getLogger('apps')
 const {fileToJson$} = require('./file')
+const {fetchCatalog$} = require('./apiService')
 const {exec$} = require('./terminal')
 const {basename} = require('path')
+const {appsCatalogUrl} = require('./config')
+
+const APPS_FILE = '/var/lib/sepal/app-manager/apps.json'
+
+const MANAGED_ENDPOINTS = ['shiny', 'jupyter', 'rstudio']
 
 const monitorApps = () =>
     interval(5000).pipe(
@@ -16,10 +22,21 @@ const monitorApps = () =>
         complete: () => log.fatal('Monitor unexpectedly completed')
     })
 
+const diskSource$ = () => fileToJson$(APPS_FILE)
+
+const source$ = () => defer(() => {
+    if (!appsCatalogUrl) return diskSource$()
+    return fetchCatalog$(appsCatalogUrl).pipe(
+        defaultIfEmpty(null),
+        switchMap(payload => payload ? of(payload) : diskSource$())
+    )
+})
+
 const apps$ = () =>
-    fileToJson$('/var/lib/sepal/app-manager/apps.json').pipe(
+    source$().pipe(
         switchMap(({apps}) => from(apps)),
         filter(({repository}) => repository),
+        filter(({endpoint}) => MANAGED_ENDPOINTS.includes(endpoint)),
         map(({endpoint = 'shiny', label, repository, branch}) => {
             const name = basename(repository)
             return {
@@ -53,4 +70,6 @@ const updateApp$ = app => {
     )
 }
 
-module.exports = {monitorApps}
+const catalog$ = () => source$()
+
+module.exports = {monitorApps, apps$, source$, catalog$}

--- a/modules/app-manager/src/config.js
+++ b/modules/app-manager/src/config.js
@@ -19,17 +19,23 @@ try {
                 .argParser(v => parseInt(v))
                 .default(DEFAULT_HTTP_PORT)
         )
+        .addOption(
+            new Option('--apps-catalog-url <value>')
+                .env('SEPAL_APPS_CATALOG_URL')
+        )
         .parse()
 } catch (error) {
     fatalError(error)
 }
 
 const {
-    port
+    port,
+    appsCatalogUrl
 } = program.opts()
 
 log.info('Configuration loaded')
 
 module.exports = {
-    port
+    port,
+    appsCatalogUrl: appsCatalogUrl || null
 }

--- a/modules/app-manager/src/routes.js
+++ b/modules/app-manager/src/routes.js
@@ -1,8 +1,24 @@
-const {sendFile, sendFileNoCache} = require('./sendFile')
+const {firstValueFrom} = require('rxjs')
+const {sendFile} = require('./sendFile')
 const {staticLabextensionsMiddleware} = require('./labextensions')
+const {catalog$} = require('./apps')
+const log = require('#sepal/log').getLogger('routes')
+
+const sendApps = async ctx => {
+    try {
+        const payload = await firstValueFrom(catalog$())
+        ctx.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+        ctx.type = 'application/json'
+        ctx.body = payload
+    } catch (error) {
+        log.error('Failed to load apps catalog:', error)
+        ctx.status = 500
+        ctx.body = {error: 'Failed to load apps'}
+    }
+}
 
 module.exports = router =>
     router
-        .get('/list', ctx => sendFileNoCache(ctx, '/var/lib/sepal/app-manager/apps.json'))
+        .get('/list', sendApps)
         .get('/images/:filename', ctx => sendFile(ctx, `/var/lib/sepal/app-manager/images/${ctx.params.filename}`))
         .get('/labextensions/:app_name/{*path}', staticLabextensionsMiddleware)


### PR DESCRIPTION
`app-manager` and `app-launcher` now read the apps list from `SEPAL_APPS_CATALOG_URL` (opt-in). Docker entries are cloned at the catalog's pinned `commit` SHA via `git checkout --detach`. Without the env var, behaviour is unchanged.

## URL options

- `https://raw.githubusercontent.com/<owner>/sepal-apps-catalog/main/apps.<env>.json` — no auth, ~2-3 min CDN lag.
- `https://cdn.jsdelivr.net/gh/<owner>/sepal-apps-catalog@main/apps.<env>.json` — no auth, usually faster purges.