### PR TITLE
Expose SEPAL_HOST to sandbox apps

### DIFF
--- a/modules/sepal-server/src/main/groovy/org/openforis/sepal/workertype/WorkerTypes.groovy
+++ b/modules/sepal-server/src/main/groovy/org/openforis/sepal/workertype/WorkerTypes.groovy
@@ -84,6 +84,7 @@ final class WorkerTypes {
                             environment: [
                                     USER_PUBLIC_KEY: userPublicKey,
                                     SEPAL_API_KEY: apiKey ?: '',
+                                    SEPAL_HOST: config.sepalHost,
                                     NVIDIA_VISIBLE_DEVICES: 'all',
                                     NVIDIA_DRIVER_CAPABILITIES: 'all',
                             ],


### PR DESCRIPTION
Adds `SEPAL_HOST` to the sandbox container environment alongside the existing `SEPAL_API_KEY`, so apps running inside the sandbox can build the SEPAL API base URL without hardcoding the deployment hostname.

Closes #384

## Test plan
- [x] Launch a sandbox session and verify `echo $SEPAL_HOST` returns the deployment host.
- [ ] Confirm existing apps that rely on `SEPAL_API_KEY` are unaffected.