### PR TITLE
Fix categorical cursor value mismatch on sparse palettes

### DIFF
--- a/modules/gui/src/app/home/map/cursorValue.jsx
+++ b/modules/gui/src/app/home/map/cursorValue.jsx
@@ -61,9 +61,11 @@ const toHsv = (rgb, {bands, min, max, gamma = 1}, dataTypes) => {
 }
 
 const toCategorical = (rgb, visParams, dataTypes) => {
-    const paddedPalette = sequence(visParams.min, visParams.max).map(() => '#000000')
+    const min = visParams.min[0]
+    const max = visParams.max[0]
+    const paddedPalette = sequence(min, max).map(() => '#000000')
     visParams.values.forEach((value, i) => {
-        paddedPalette[value - visParams.min] = visParams.palette[i]
+        paddedPalette[value - min] = visParams.palette[i]
     })
     const continuous = toContinuous(rgb, {...visParams, palette: paddedPalette}, dataTypes)
     if (continuous.length && visParams.values) {
@@ -91,8 +93,8 @@ const toContinuous = (rgb, visParams, dataTypes) => {
 
         const fromValue = fromRgbValue.value
         const toValue = toRgbValue.value
-        const error = getError(channels)
         const weightedMeanFactor = getWeightedMeanFactor(channels)
+        const error = getError(channels, weightedMeanFactor)
         // const preciseValue = fromValue + weightedMeanFactor * (toValue - fromValue)
         // const value = selectFrom(dataTypes, [visParams.bands[0], 'precision']) === 'int'
         //     ? Math.round(parseFloat(preciseValue))
@@ -123,11 +125,14 @@ const toContinuous = (rgb, visParams, dataTypes) => {
     return []
 }
 
-// Calculate the error as the multidimensional color distance (1 to 3 bands)
-const getError = channels =>
+// Color distance between the cursor RGB and the point on the segment at `factor`.
+// Using a single factor (instead of each channel's own) ensures colors off the
+// segment line get a real non-zero error, instead of false-matching every color
+// inside the from→to RGB bounding box.
+const getError = (channels, factor) =>
     Math.sqrt(
         _.sum(
-            channels.map(({value, from, range, factor}) => {
+            channels.map(({value, from, range}) => {
                 const calculatedC = Math.round(from + factor * range)
                 return Math.pow(calculatedC - value, 2)
             })

--- a/modules/gui/src/app/home/map/cursorValue.test.js
+++ b/modules/gui/src/app/home/map/cursorValue.test.js
@@ -93,9 +93,18 @@ test('toBandValues(${rgb}, ${visParams}) === ${result}')
             visParams: {type: 'categorical', bands: ['index'], values: [1, 2, 3], min: [1], max: [3], palette: ['black', 'green', 'white']},
             result: [2]
         },
-        // {
-        //     rgb: [177, 95, 131],
-        //     visParams: {type: 'categorical', bands: ['index'], values: [5, 200, 1000], min: [5], max: [1000], palette: ['#042333', '#b15f82', '#e8fa5b']},
-        //     result: [200]
-        // },
+        {
+            rgb: [177, 95, 131],
+            visParams: {type: 'categorical', bands: ['index'], values: [5, 200, 1000], min: [5], max: [1000], palette: ['#042333', '#b15f82', '#e8fa5b']},
+            result: [200]
+        },
+        {
+            // Reproduces the gfc_classification mismatch: cursor (0,100,0) is exactly
+            // #006400 (value 40), but its R and B channels lie inside the bounding
+            // box of the padded #d3d3d3 -> #000000 segment near value 30, which
+            // produces a spurious zero error when each channel uses its own factor.
+            rgb: [0, 100, 0],
+            visParams: {type: 'categorical', bands: ['index'], values: [1, 30, 40, 50], min: [1], max: [50], palette: ['#000000', '#d3d3d3', '#006400', '#90ee90']},
+            result: [40]
+        },
     )


### PR DESCRIPTION
## Summary

- `getError` in `cursorValue.jsx` let each RGB channel pick its own factor along a palette segment, so any color inside the segment's RGB bounding box scored zero error — not only colors on the segment line. On sparse categorical palettes (padded with `#000000`) this caused unrelated gray→black segments to false-match real colors like `#006400`, snapping the legend to the wrong value.
- Concretely on the `gfc_classification` layer, hovering a stable-forest pixel (`rgb=(0,100,0)`, `#006400`, value `40`) reported `30` (non forest, `#d3d3d3`) because the padded `#d3d3d3 → #000000` segment scored a spurious zero error and won the `_.minBy` tie.
- Fix: compute a single shared `weightedMeanFactor` first and pass it to `getError`, so off-line colors produce a real non-zero distance.
- Also unwrap `visParams.min/max` in `toCategorical` to scalars instead of relying on single-element array coercion.

## Test plan

- [x] Existing 13 tests in `modules/gui/src/app/home/map/cursorValue.test.js` still pass.
- [x] Re-enabled the previously commented sparse-palette categorical test.
- [x] Added a new regression test mirroring the `gfc_classification` geometry (`rgb=[0,100,0]` over `values=[1,30,40,50]`, palette `[#000000,#d3d3d3,#006400,#90ee90]`) which fails on master (returns `30`) and passes with the fix (returns `40`).
- [x] `npx vitest run src/app/home/map/cursorValue.test.js` → 15/15 passing.
- [x] Smoke-test in the running GUI by hovering over a `gfc_classification` layer and confirming the legend value matches the pixel category.