### PR TITLE
fix: throw IllegalArgumentException for invalid paths in FileSystem

### DIFF
--- a/common/src/main/groovy/org/openforis/sepal/util/FileSystem.groovy
+++ b/common/src/main/groovy/org/openforis/sepal/util/FileSystem.groovy
@@ -49,6 +49,7 @@ class FileSystem {
 
     private static void illegalArgument(String error) {
         LOG.error(error)
+        throw new IllegalArgumentException(error)
     }
 
     static Double getFileSize(File file) {


### PR DESCRIPTION
1. Summary: Corrected the `FileSystem` utility methods `toFile` and `toDir` to throw `IllegalArgumentException` when paths are invalid, instead of merely logging the error. 

2. Rationale: The previous implementation allowed invalid file system operations to proceed after logging, which could lead to unpredictable behavior and potential downstream errors when methods expected a valid File object. 

3. Technical Impact: Improves robustness by enforcing validation and ensuring fail-fast behavior when file system operations are initialized with incorrect paths, preventing erroneous object usage.