### PR TITLE
Sandbox: expose env vars to login shells + raise uv GPU build timeout

### DIFF
--- a/modules/geospatial-toolkit/script/init_gpu.sh
+++ b/modules/geospatial-toolkit/script/init_gpu.sh
@@ -6,6 +6,9 @@ echo "***************************"
 echo "*** Installing GPU libs ***"
 echo "***************************"
 
+# Mainly for local envs: large CUDA wheel downloads can time out.
+export UV_HTTP_TIMEOUT=600
+
 # Tensorflow version compatibility: 
 #   https://www.tensorflow.org/install/source#gpu
 

--- a/modules/geospatial-toolkit/script/init_post.sh
+++ b/modules/geospatial-toolkit/script/init_post.sh
@@ -24,6 +24,8 @@ printf '%s\n' \
     'PYTHONPATH=/usr/local/lib/orfeo/lib/otb/python' \
     'LD_LIBRARY_PATH=/lib/:/lib/x86_64-linux-gnu/:/lib32/:/usr/lib/x86_64-linux-gnu/libfakeroot/:/usr/local/cuda/targets/x86_64-linux/lib/:/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib:/usr/local/lib/TensorRT/lib:/usr/local/lib/orfeo/lib:' \
     'GMTSAR=/usr/local/GMTSAR' \
+    "PIP_BREAK_SYSTEM_PACKAGES=1" \
+    "UV_BREAK_SYSTEM_PACKAGES=1" \
     >> /etc/environment
 
 # Remove redundant files

--- a/modules/sandbox/script/init_container.sh
+++ b/modules/sandbox/script/init_container.sh
@@ -52,6 +52,10 @@ printf '%s\n' \
 cp /etc/environment /etc/R/Renviron.site
 sed -i -e 's/\/usr\/lib\/x86_64-linux-gnu/\/usr\/lib\/x86_64-linux-gnu:\/lib\/x86_64-linux-gnu/g' /usr/lib/R/etc/ldpaths
 
+printf '%s\n' \
+    "SEPAL_HOST=$SEPAL_HOST" \
+    >> /etc/environment
+
 userHome=/home/$sandbox_user
 cp -n /etc/skel/.bashrc "$userHome"
 cp -n /etc/skel/.profile "$userHome"


### PR DESCRIPTION
Persist sandbox env vars to `/etc/environment` so they're available in the Terminal and Jupyter sessions:

- `SEPAL_HOST` — runtime (`init_container.sh`)
- `PIP_BREAK_SYSTEM_PACKAGES` / `UV_BREAK_SYSTEM_PACKAGES` — build-time (`init_post.sh`)

Also raised `UV_HTTP_TIMEOUT` to 600s (`init_gpu.sh`) for large CUDA wheel downloads, mainly for local envs.

Tested in a notebook: `SEPAL_HOST` present, `pip install` works.