### PR TITLE
Fix loading referenced recipes in gee dev env

### DIFF
--- a/modules/gee/docker-compose.override.yml
+++ b/modules/gee/docker-compose.override.yml
@@ -18,3 +18,5 @@ services:
       - ${SEPAL_PROJECT_DIR}/modules/gee:/usr/local/src/sepal/modules/gee
     environment:
       INSTANCES: "3"
+    extra_hosts:
+      - '${SEPAL_HOST}:host-gateway'

--- a/modules/gee/start.sh
+++ b/modules/gee/start.sh
@@ -8,7 +8,7 @@ if [[ "${DEPLOY_ENVIRONMENT}" == "DEV" ]]
 then
   echo "Starting nodemon"
   [[ -d node_modules ]] || npm install
-  NODE_TLS_REJECT_UNAUTHORIZED=1 exec nodemon \
+  NODE_TLS_REJECT_UNAUTHORIZED=0 exec nodemon \
     --watch "${MODULE}/src" \
     --watch "${MODULE}/config" \
     --watch "${SHARED}" \


### PR DESCRIPTION
Loading a recipe that references another recipe (e.g. Classification → Mosaic) fails in the dev environment: `gee` can't reach the SEPAL endpoint from inside its container.

Two dev-only fixes, both matching what the other modules already do:

- `docker-compose.override.yml`: map `${SEPAL_HOST}` to `host-gateway`.
- `start.sh`: set `NODE_TLS_REJECT_UNAUTHORIZED=0` in the `DEV` branch (gee was the only node module without it).

Production is unaffected.
