### PR TITLE
Add tippecanoe to sandbox image

### DIFF
--- a/modules/sandbox/Dockerfile
+++ b/modules/sandbox/Dockerfile
@@ -33,7 +33,7 @@ RUN chmod +x /usr/local/lib/sepal/python/shared/stack_time_series.py && \
 ADD modules/${MODULE_NAME}/script/init_ost.sh /script/
 RUN chmod u+x /script/init_ost.sh && sync && /script/init_ost.sh
 
-RUN apt-get update && apt-get install -y htop ncdu
+RUN apt-get update && apt-get install -y htop ncdu tippecanoe
 
 ADD modules/${MODULE_NAME}/script/init_clojure.sh /script/
 RUN chmod u+x /script/init_clojure.sh && sync && /script/init_clojure.sh


### PR DESCRIPTION
Adds `tippecanoe` to the sandbox image via the existing apt line, making it available in user sandboxes for building vector tilesets (MBTiles/PMTiles) from GeoJSON.

Ubuntu noble universe ships 2.49.0-1build1, which includes `tippecanoe`, `tile-join`, `tippecanoe-decode`, `tippecanoe-enumerate` and `tippecanoe-json-tool`.

Package availability confirmed against the noble archive; not yet verified with a full sandbox image build.