### PR TITLE
fix(gui): make recipe type tags single-select filter

### DIFF
--- a/modules/gui/src/app/home/body/process/createRecipe.jsx
+++ b/modules/gui/src/app/home/body/process/createRecipe.jsx
@@ -21,6 +21,7 @@ import {Panel} from '~/widget/panel/panel'
 import {SearchBox} from '~/widget/searchBox'
 
 import styles from './createRecipe.module.css'
+import {recipeTypeMatchesTagFilter} from './createRecipeTagFilter'
 import {getRecipeType} from './recipeTypeRegistry'
 
 const mapStateToProps = state => {
@@ -78,13 +79,13 @@ class _CreateRecipe extends React.Component {
         this.closePanel = this.closePanel.bind(this)
         this.showRecipeTypeInfo = this.showRecipeTypeInfo.bind(this)
         this.setTextFilter = this.setTextFilter.bind(this)
-        this.setTagsFilter = this.setTagsFilter.bind(this)
+        this.setTagFilter = this.setTagFilter.bind(this)
     }
 
     state = {
         selectedRecipeType: null,
         textFilterValues: [],
-        tagsFilter: []
+        tagFilter: null
     }
 
     render() {
@@ -212,7 +213,7 @@ class _CreateRecipe extends React.Component {
     }
 
     renderTagsFilter() {
-        const {tags, tagsFilter} = this.state
+        const {tags, tagFilter} = this.state
 
         const recipeOptions = tags?.map(tag => ({
             label: msg(`process.recipe.newRecipe.tags.${tag}`),
@@ -221,9 +222,8 @@ class _CreateRecipe extends React.Component {
 
         const options = [{
             label: msg('process.recipe.newRecipe.tags.ALL'),
-            // value: null,
-            deselect: true
-        }, ...recipeOptions]
+            value: null
+        }, ...(recipeOptions || [])]
 
         return (
             <Buttons
@@ -231,9 +231,8 @@ class _CreateRecipe extends React.Component {
                 layout='horizontal'
                 spacing='tight'
                 options={options}
-                multiple
-                selected={tagsFilter}
-                onSelect={this.setTagsFilter}
+                selected={tagFilter}
+                onSelect={this.setTagFilter}
             />
         )
     }
@@ -275,8 +274,8 @@ class _CreateRecipe extends React.Component {
         this.setState({textFilterValues})
     }
 
-    setTagsFilter(tagsFilter) {
-        this.setState({tagsFilter})
+    setTagFilter(tagFilter) {
+        this.setState({tagFilter})
     }
 
     getFilteredRecipeTypes() {
@@ -306,8 +305,8 @@ class _CreateRecipe extends React.Component {
     }
 
     recipeTypeMatchesTags(recipeType) {
-        const {tagsFilter} = this.state
-        return _.every(tagsFilter, tag => recipeType?.tags?.includes(tag))
+        const {tagFilter} = this.state
+        return recipeTypeMatchesTagFilter(recipeType, tagFilter)
     }
 
     getHighlightMatcher() {

--- a/modules/gui/src/app/home/body/process/createRecipeTagFilter.js
+++ b/modules/gui/src/app/home/body/process/createRecipeTagFilter.js
@@ -1,0 +1,7 @@
+/**
+ * Recipe type tag filter for the "Add recipe" panel.
+ * A null tagFilter means "ALL" (no restriction).
+ * Selection is single-value (radio), not multi-select AND.
+ */
+export const recipeTypeMatchesTagFilter = (recipeType, tagFilter) =>
+    tagFilter == null || Boolean(recipeType?.tags?.includes(tagFilter))

--- a/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
+++ b/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
@@ -1,0 +1,33 @@
+import {describe, expect, it} from 'vitest'
+
+import {recipeTypeMatchesTagFilter} from './createRecipeTagFilter'
+
+describe('recipeTypeMatchesTagFilter', () => {
+    const changeAlerts = {id: 'CHANGE_ALERTS', tags: ['CHANGE', 'ALERTS']}
+    const opticalMosaic = {id: 'MOSAIC', tags: ['MOSAIC']}
+    const asset = {id: 'ASSET', tags: []}
+    const untagged = {id: 'UNTAGGED'}
+
+    it('shows every recipe when no tag is selected (ALL)', () => {
+        expect(recipeTypeMatchesTagFilter(changeAlerts, null)).toBe(true)
+        expect(recipeTypeMatchesTagFilter(opticalMosaic, null)).toBe(true)
+        expect(recipeTypeMatchesTagFilter(asset, null)).toBe(true)
+        expect(recipeTypeMatchesTagFilter(untagged, null)).toBe(true)
+    })
+
+    it('matches only recipes that include the selected tag', () => {
+        expect(recipeTypeMatchesTagFilter(changeAlerts, 'CHANGE')).toBe(true)
+        expect(recipeTypeMatchesTagFilter(changeAlerts, 'ALERTS')).toBe(true)
+        expect(recipeTypeMatchesTagFilter(opticalMosaic, 'MOSAIC')).toBe(true)
+        expect(recipeTypeMatchesTagFilter(opticalMosaic, 'CHANGE')).toBe(false)
+        expect(recipeTypeMatchesTagFilter(asset, 'MOSAIC')).toBe(false)
+        expect(recipeTypeMatchesTagFilter(untagged, 'CHANGE')).toBe(false)
+    })
+
+    it('treats a single selected tag as exclusive (not multi-select AND)', () => {
+        // Selecting ALERTS alone must include change-alerts recipes without also
+        // requiring CHANGE — multi-select AND filtering was the previous bug mode.
+        expect(recipeTypeMatchesTagFilter(changeAlerts, 'ALERTS')).toBe(true)
+        expect(recipeTypeMatchesTagFilter({id: 'X', tags: ['CHANGE']}, 'ALERTS')).toBe(false)
+    })
+})

--- a/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
+++ b/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
@@ -7,12 +7,17 @@ describe('recipeTypeMatchesTagFilter', () => {
     const opticalMosaic = {id: 'MOSAIC', tags: ['MOSAIC']}
     const asset = {id: 'ASSET', tags: []}
     const untagged = {id: 'UNTAGGED'}
+    const allTypes = [changeAlerts, opticalMosaic, asset, untagged]
+
+    const filterTypes = tagFilter =>
+        allTypes.filter(type => recipeTypeMatchesTagFilter(type, tagFilter))
 
     it('shows every recipe when no tag is selected (ALL)', () => {
         expect(recipeTypeMatchesTagFilter(changeAlerts, null)).toBe(true)
         expect(recipeTypeMatchesTagFilter(opticalMosaic, null)).toBe(true)
         expect(recipeTypeMatchesTagFilter(asset, null)).toBe(true)
         expect(recipeTypeMatchesTagFilter(untagged, null)).toBe(true)
+        expect(filterTypes(null).map(t => t.id)).toEqual(allTypes.map(t => t.id))
     })
 
     it('matches only recipes that include the selected tag', () => {
@@ -22,6 +27,8 @@ describe('recipeTypeMatchesTagFilter', () => {
         expect(recipeTypeMatchesTagFilter(opticalMosaic, 'CHANGE')).toBe(false)
         expect(recipeTypeMatchesTagFilter(asset, 'MOSAIC')).toBe(false)
         expect(recipeTypeMatchesTagFilter(untagged, 'CHANGE')).toBe(false)
+        expect(filterTypes('MOSAIC').map(t => t.id)).toEqual(['MOSAIC'])
+        expect(filterTypes('CHANGE').map(t => t.id)).toEqual(['CHANGE_ALERTS'])
     })
 
     it('treats a single selected tag as exclusive (not multi-select AND)', () => {
@@ -29,5 +36,12 @@ describe('recipeTypeMatchesTagFilter', () => {
         // requiring CHANGE — multi-select AND filtering was the previous bug mode.
         expect(recipeTypeMatchesTagFilter(changeAlerts, 'ALERTS')).toBe(true)
         expect(recipeTypeMatchesTagFilter({id: 'X', tags: ['CHANGE']}, 'ALERTS')).toBe(false)
+        expect(filterTypes('ALERTS').map(t => t.id)).toEqual(['CHANGE_ALERTS'])
+    })
+
+    it('handles missing tags safely', () => {
+        expect(recipeTypeMatchesTagFilter(null, 'CHANGE')).toBe(false)
+        expect(recipeTypeMatchesTagFilter(undefined, null)).toBe(true)
+        expect(recipeTypeMatchesTagFilter({id: 'NO_TAGS_KEY'}, 'ALERTS')).toBe(false)
     })
 })

--- a/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
+++ b/modules/gui/src/app/home/body/process/createRecipeTagFilter.test.js
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest'
 
 import {recipeTypeMatchesTagFilter} from './createRecipeTagFilter'
 
+// Regression coverage for #340 — Add recipe tag chips must be single-select, not AND multi-select.
 describe('recipeTypeMatchesTagFilter', () => {
     const changeAlerts = {id: 'CHANGE_ALERTS', tags: ['CHANGE', 'ALERTS']}
     const opticalMosaic = {id: 'MOSAIC', tags: ['MOSAIC']}


### PR DESCRIPTION
Fixes #340.

The Add recipe tag chips currently allow multiple selections and apply AND filtering, so most tag combinations hide every recipe. This changes the picker to single-select behavior, matching the existing app-list filter:

- one selected tag at a time, or ALL
- inclusion matching for the selected tag
- a small pure helper with unit coverage

Validation:
`cd modules/gui && npx vitest run src/app/home/body/process/createRecipeTagFilter.test.js`
Result: 4 passed.

Issue #305 is a separate UI-state bug and is not included.