### PR TITLE
Add PYEO_ALERTS recipe (PyEO change alerts)

### DIFF
--- a/lib/js/ee/src/imageFactory.js
+++ b/lib/js/ee/src/imageFactory.js
@@ -19,6 +19,7 @@ const factory = {
     'CHANGE_ALERTS': () => load('./timeSeries/changeAlerts.js'),
     'BAYTS_HISTORICAL': () => load('./bayts/baytsHistorical.js'),
     'BAYTS_ALERTS': () => load('./bayts/baytsAlerts.js'),
+    'PYEO_ALERTS': () => load('./pyeo/pyeoAlerts.js'),
     'CLASSIFICATION': () => load('./classification/classification.js'),
     'UNSUPERVISED_CLASSIFICATION': () => load('./unsupervisedClassification/unsupervisedClassification.js'),
     'REGRESSION': () => load('./regression/regression.js'),

--- a/lib/js/ee/src/pyeo/params.js
+++ b/lib/js/ee/src/pyeo/params.js
@@ -1,0 +1,35 @@
+// Maps the pyeoAlerts recipe model.pyeoAlertsOptions to the parameter object expected by
+// UoL's runPyeoChangeAlerts. Pure (no Earth Engine) so it is unit-tested.
+
+const DEFAULTS = {
+    minRequiredClassifierDetectionsThreshold: 5,
+    percentageProbabilityThreshold: 50,
+    minRequiredFromDetectionsThreshold: 2,
+    minRequiredToDetectionsThreshold: 2,
+    minRequiredDeltaIndexDetectionsThreshold: 5
+}
+
+// UoL convention: a threshold of -2.0 lets every transition through the index
+// gate, i.e. the gate is effectively off.
+const INDEX_GATE_OFF_THRESHOLD = -2.0
+
+export const toUolParams = ({
+    changeFromClasses = [],
+    changeToClasses = [],
+    minConsecutiveDetections = 2,
+    indexGate
+} = {}) => ({
+    changeFromClasses,
+    changeToClasses,
+    minRequiredValidatedDetectionsThreshold: minConsecutiveDetections,
+    minRequiredClassifierDetectionsThreshold: DEFAULTS.minRequiredClassifierDetectionsThreshold,
+    percentageProbabilityThreshold: DEFAULTS.percentageProbabilityThreshold,
+    minRequiredFromDetectionsThreshold: DEFAULTS.minRequiredFromDetectionsThreshold,
+    minRequiredToDetectionsThreshold: DEFAULTS.minRequiredToDetectionsThreshold,
+    indexGate: {
+        use: !!indexGate,
+        index: indexGate ? indexGate.index : 'ndvi',
+        threshold: indexGate ? indexGate.threshold : INDEX_GATE_OFF_THRESHOLD,
+        minRequiredDeltaIndexDetectionsThreshold: DEFAULTS.minRequiredDeltaIndexDetectionsThreshold
+    }
+})

--- a/lib/js/ee/src/pyeo/params.test.js
+++ b/lib/js/ee/src/pyeo/params.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+
+import {toUolParams} from './params.js'
+
+test('passes change classes through', () => {
+    const p = toUolParams({changeFromClasses: [1], changeToClasses: [2, 3]})
+    assert.deepEqual(p.changeFromClasses, [1])
+    assert.deepEqual(p.changeToClasses, [2, 3])
+})
+
+test('maps minConsecutiveDetections to the validated-detections threshold', () => {
+    const p = toUolParams({minConsecutiveDetections: 4})
+    assert.equal(p.minRequiredValidatedDetectionsThreshold, 4)
+})
+
+test('applies UoL default thresholds', () => {
+    const p = toUolParams({})
+    assert.equal(p.minRequiredClassifierDetectionsThreshold, 5)
+    assert.equal(p.percentageProbabilityThreshold, 50)
+    assert.equal(p.minRequiredFromDetectionsThreshold, 2)
+    assert.equal(p.minRequiredToDetectionsThreshold, 2)
+    assert.equal(p.minRequiredValidatedDetectionsThreshold, 2)
+})
+
+test('index gate on passes the chosen index and threshold through', () => {
+    const p = toUolParams({indexGate: {index: 'nbr', threshold: 0.2}})
+    assert.equal(p.indexGate.use, true)
+    assert.equal(p.indexGate.index, 'nbr')
+    assert.equal(p.indexGate.threshold, 0.2)
+    assert.equal(p.indexGate.minRequiredDeltaIndexDetectionsThreshold, 5)
+})
+
+test('index gate off uses pass-through threshold -2.0 and defaults to ndvi', () => {
+    const p = toUolParams({indexGate: undefined})
+    assert.equal(p.indexGate.use, false)
+    assert.equal(p.indexGate.threshold, -2.0)
+    assert.equal(p.indexGate.index, 'ndvi')
+})

--- a/lib/js/ee/src/pyeo/pyeoAlerts.js
+++ b/lib/js/ee/src/pyeo/pyeoAlerts.js
@@ -1,0 +1,204 @@
+import {forkJoin, map, of, switchMap} from 'rxjs'
+
+import {toGeometry$} from '#sepal/ee/aoi'
+import ee from '#sepal/ee/ee'
+import imageFactory from '#sepal/ee/imageFactory'
+import {calculateIndex} from '#sepal/ee/optical/indexes'
+import {loadRecipe$} from '#sepal/ee/recipe'
+import recipeRef from '#sepal/ee/recipeRef'
+import {getCollection$} from '#sepal/ee/timeSeries/collection'
+import {validateEEImage} from '#sepal/ee/validate'
+
+import {toUolParams} from './params.js'
+import {runPyeoChangeAlerts} from './runPyeoChangeAlerts.js'
+
+const CHANGE_REPORT_BANDS = [
+    'available_image_count', 'occluded_count', 'total_changes',
+    'first_change_date_above_threshold', 'post_fcd_change_count',
+    'post_fcd_nochange_count', 'post_fcd_occluded_count',
+    'post_fcd_valid_image_count', 'post_fcd_change_repeatability_pct',
+    'binary_timeseries_decision', 'fcd_decision_map', 'delta_index_change_count',
+    'binary_delta_index_decision_map', 'binary_delta_class_decision_map',
+    'binary_combined_delta_decision_map', 'from_class_count', 'to_class_count',
+    'binary_decision_from_to_map'
+]
+
+// Baseline and monitoring gate_index are int16 ×INDEX_SCALE — the scale getCollection$ gives
+// indices — so they compare directly; the threshold below is scaled to match.
+const INDEX_SCALE = 10000
+
+// fcd_decision_map is epoch ms. The map renders a date only for dataType:'fractionalYears', decoded
+// CALENDAR-style by format.fractionalYearsToDate (year + fraction of that calendar year). Encode to
+// match — a uniform ms/365.25 from 1970 drifts ~1 day and flips the year near Jan 1. Piecewise over
+// the window's years; mirrors changeAlerts' ee.Date().getFraction('year'). No-change pixels stay masked.
+const toFractionalYear = (msBand, startYear, endYear) => {
+    const years = []
+    for (let year = startYear; year <= endYear; year++) {
+        years.push(year)
+    }
+    const fractionalYear = years.reduce((acc, year) => {
+        const yearStart = ee.Date.fromYMD(year, 1, 1).millis()
+        const nextYearStart = ee.Date.fromYMD(year + 1, 1, 1).millis()
+        const value = msBand.subtract(yearStart).divide(nextYearStart.subtract(yearStart)).add(year)
+        return acc.where(msBand.gte(yearStart).and(msBand.lt(nextYearStart)), value)
+    }, msBand)
+    return fractionalYear.updateMask(msBand.mask())
+}
+
+const pyeoAlerts = (recipe, {selection = []} = {}) => {
+    const {model} = recipe
+    const {monitoringStart, monitoringEnd} = model.dates
+    const classificationId = model.sources.classification
+    const {changeFromClasses = [], changeToClasses = []} = model.sources || {}
+    const uolParams = toUolParams({...model.pyeoAlertsOptions, changeFromClasses, changeToClasses})
+    const gateIndex = uolParams.indexGate.index
+    uolParams.indexGate.threshold *= INDEX_SCALE
+
+    const toImage$ = () => {
+        // Empty From/To builds ee.ImageCollection([]).max() and fails server-side after a long run;
+        // short-circuit with a friendly error.
+        if (!changeFromClasses.length || !changeToClasses.length) {
+            return of(noChangeClassesError())
+        }
+        return toGeometry$(model.aoi).pipe(
+            switchMap(geometry =>
+                forkJoin({
+                    classificationRecipe: recipeRef({id: classificationId}).getRecipe$(),
+                    classificationInputs: loadClassificationInputs$()
+                }).pipe(
+                    switchMap(({classificationRecipe, classificationInputs: {eeBaselineGateIndex, classifierBands}}) =>
+                        forkJoin({
+                            trainingData: classificationRecipe.getTrainingData$(),
+                            eeClassificationImage: classificationRecipe.getImage$(),
+                            monitoringCollection: monitoringCollection$(classifierBands, geometry)
+                        }).pipe(
+                            map(({trainingData, eeClassificationImage, monitoringCollection}) =>
+                                toChangeReport({
+                                    geometry, classificationRecipe, trainingData, eeClassificationImage,
+                                    eeBaselineGateIndex, monitoringCollection
+                                })
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    // The classification's own input imagery, loaded once: the bands it carries (so monitoring can
+    // reproduce what the classifier references) and its gate_index. RECIPE_REF mosaics compute the
+    // index band directly; an ASSET can't synthesize bands, so we pull it and compute the index.
+    const loadClassificationInputs$ = () =>
+        loadRecipe$(classificationId).pipe(
+            switchMap(classification => {
+                const images = (classification.model.inputImagery && classification.model.inputImagery.images) || []
+                if (images.length !== 1) {
+                    throw new Error('pyeoAlerts: the classification must have exactly one input image')
+                }
+                const input = images[0]
+                const eeBaselineGateIndex$ = input.type === 'RECIPE_REF'
+                    ? imageFactory(input, {selection: [gateIndex]}).getImage$().pipe(
+                        map(image => image.select([gateIndex], ['gate_index']))
+                    )
+                    : imageFactory(input).getImage$().pipe(
+                        map(image => calculateIndex(image, gateIndex).multiply(INDEX_SCALE).int16().rename('gate_index'))
+                    )
+                return forkJoin({
+                    eeBaselineGateIndex: eeBaselineGateIndex$,
+                    classifierBands: imageFactory(input).getBands$()
+                })
+            })
+        )
+
+    // Per-scene monitoring collection from this recipe's editable sources, via the timeSeries builder.
+    // We null sources.classification (else it runs its own regression/probability classifier) and
+    // classify to categorical 'class' ourselves; dates renamed to its {startDate, endDate} shape.
+    // Mirrors changeAlerts.js:184-191.
+    const monitoringCollection$ = (classifierBands, geometry) =>
+        getCollection$({
+            recipe: {model: {
+                ...model,
+                dates: {startDate: monitoringStart, endDate: monitoringEnd},
+                sources: {...model.sources, classification: null}
+            }},
+            geometry,
+            bands: classifierBands.includes(gateIndex)
+                ? classifierBands
+                : [...classifierBands, gateIndex]
+        })
+
+    const toChangeReport = ({geometry, classificationRecipe, trainingData, eeClassificationImage, eeBaselineGateIndex, monitoringCollection}) => {
+        const classifiedBaseline = toClassifiedBaseline(eeClassificationImage, eeBaselineGateIndex)
+        // EE doesn't guarantee order after filter/map and the algorithm walks scenes chronologically.
+        const classifiedMonitoringCollection = monitoringCollection
+            .sort('system:time_start')
+            .map(image => classifyScene(image, classificationRecipe, trainingData))
+        const changeReport = runPyeoChangeAlerts({
+            aoi: geometry,
+            classifiedBaseline,
+            classifiedMonitoringCollection,
+            ...uolParams
+        }).clip(geometry)
+        // Re-express the change-date band from epoch ms to a calendar fractional year so the map
+        // decoder renders the correct date (see toFractionalYear).
+        const startYear = Number(monitoringStart.slice(0, 4))
+        const endYear = Number(monitoringEnd.slice(0, 4))
+        const report = changeReport.addBands(
+            toFractionalYear(changeReport.select('fcd_decision_map'), startYear, endYear).rename('fcd_decision_map'),
+            null, true
+        )
+        const image = selection.length ? report.select(selection) : report
+        return validateEEImage({
+            valid: monitoringCollection.limit(1).size(),
+            image,
+            error: {
+                userMessage: {
+                    message: 'No monitoring images match the recipe configuration. Update the dates or sources.',
+                    key: 'process.pyeoAlerts.error.noImages'
+                },
+                statusCode: 400
+            }
+        })
+    }
+
+    // Classify a scene to categorical 'classification' + carry its already-scaled gate_index. The
+    // classifier derives its own covariates from raw bands, so no pre-added tasseled cap.
+    const classifyScene = (image, classificationRecipe, trainingData) =>
+        classificationRecipe
+            .classifyImage(image, ['class'], trainingData)
+            .rename(['classification'])
+            .addBands(image.select([gateIndex], ['gate_index']))
+            .copyProperties(image, ['system:time_start'])
+
+    const toClassifiedBaseline = (eeClassificationImage, eeBaselineGateIndex) =>
+        eeClassificationImage
+            .select(['class'], ['classification'])
+            .addBands(eeBaselineGateIndex)
+
+    const noChangeClassesError = () =>
+        validateEEImage({
+            valid: 0,
+            image: ee.Image(0),
+            error: {
+                userMessage: {
+                    message: 'Select at least one "From" class and one "To" class in the change-detection options.',
+                    key: 'process.pyeoAlerts.error.noChangeClasses'
+                },
+                statusCode: 400
+            }
+        })
+
+    return {
+        getImage$() {
+            return toImage$()
+        },
+        getBands$() {
+            return of(CHANGE_REPORT_BANDS)
+        },
+        getGeometry$() {
+            return toGeometry$(model.aoi)
+        }
+    }
+}
+
+export default pyeoAlerts

--- a/lib/js/ee/src/pyeo/runPyeoChangeAlerts.js
+++ b/lib/js/ee/src/pyeo/runPyeoChangeAlerts.js
@@ -1,0 +1,295 @@
+import ee from '#sepal/ee/ee'
+/**
+ * PyEO Change Alerts — GEE function.
+ *
+ * The input parameters and output band spec below are the contract between
+ * UoL and SEPAL.
+ *
+ * This function does not classify. It receives baseline and monitoring
+ * inputs that already carry a 'class' band; the SEPAL recipe wrapper
+ * applies the user's classification recipe before calling in.
+ *
+ * @param {Object} params
+ * @param {ee.Geometry|ee.FeatureCollection} params.aoi
+ *     Area of interest. Output should be clipped to this.
+ * @param {ee.Image} params.classifiedBaseline
+ *     Baseline classification map with a 'class' band (integer class IDs).
+ *     If params.indexGate is set, must also carry the gate index band
+ *     (`gate_index`).
+ * @param {ee.ImageCollection} params.classifiedMonitoringCollection
+ *     Monitoring images, time-sorted (system:time_start ascending). Each
+ *     image carries the same 'class' band (and optional gate band) as the
+ *     baseline.
+ * @param {number[]} params.changeFromClasses
+ *     Class IDs that, in the BASELINE, count as the "from" side of a change.
+ * @param {number[]} params.changeToClasses
+ *     Class IDs that, in any MONITORING image, count as the "to" side.
+ * @param {number} [params.minConsecutiveDetections=2]
+ *     Temporal-confidence parameter. Interpretation up to the algorithm.
+ * @param {{index: string, threshold: number}} [params.indexGate]
+ *     Optional spectral confirmation: alert is confirmed only when the
+ *     `index` drops by at least `threshold` vs. the baseline.
+ *
+ * @returns {ee.Image} Multi-band alert raster, clipped to AOI. Required bands:
+ *     - first_change_date   days since 2000-01-01, masked where no alert
+ *     - detection_count     total monitoring images flagged at this pixel
+ *     - consecutive_count   longest consecutive run of detections
+ *     - from_class          baseline class ID at the alert pixel
+ *     - to_class            most recent monitoring class ID at the alert pixel
+ *     - confidence          [0..1]
+ *     - dindex_drop         (only when indexGate is set) index change at confirmation
+ *
+ *     Pixels with no alert should be masked out. The output band names are
+ *     part of the contract — SEPAL's wrapper references them. If the
+ *     algorithm needs a different schema, flag it so we update both sides.
+ *
+ *     Keep the body server-side. Use .map() / .iterate() / ee.Algorithms.If.
+ *     Avoid .getInfo() and JS for-loops over ee.List — they fail at scale.
+ */
+ // 
+ // potential inputs: index-gate boolean (on/off), index threshold
+ //
+export const runPyeoChangeAlerts = params => {
+  // ==============================================================================
+  // 1. INPUT PARAMETERS
+  // ==============================================================================
+  var aoi = params.aoi
+  var classifiedBaseline = params.classifiedBaseline
+  var classifiedMonitoringCollection = params.classifiedMonitoringCollection
+  var changeFromClasses = params.changeFromClasses
+  var changeToClasses = params.changeToClasses
+  var minRequiredValidatedDetectionsThreshold = params.minRequiredValidatedDetectionsThreshold || 2
+  var minRequiredClassifierDetectionsThreshold = params.minRequiredClassifierDetectionsThreshold || 5
+  var percentageProbabilityThreshold = params.percentageProbabilityThreshold || 50
+  var minRequiredFromDetectionsThreshold = params.minRequiredFromDetectionsThreshold || 2
+  var minRequiredToDetectionsThreshold = params.minRequiredToDetectionsThreshold || 2
+  var indexGate = params.indexGate || {use: false, index: 'ndvi', threshold: 0.3, minRequiredDeltaIndexDetectionsThreshold: 5}
+  
+  // if user has opted to not use the index gate (as a threshold), then set threshold to let all detections through
+  // if (!(indexGate.use)) {
+  //   indexGate.threshold = -2.0
+  // }
+  // if no minimum index-drop detections past the threshold argument is supplied, this is the default
+  if (!(indexGate.minRequiredDeltaIndexDetectionsThreshold)) {
+    indexGate.minRequiredDeltaIndexDetectionsThreshold = 5
+  }
+
+  // ==============================================================================
+  // 2. CHANGE DETECTION LOGIC
+  // ==============================================================================
+
+  var baselineClassification = classifiedBaseline.select("classification");
+  var baselineIndex = classifiedBaseline.select("gate_index");
+  
+  // create a fromMask that works for multiple classes
+  // this mask is used to count changes for pixels from a FROM class to a TO class
+  var fromMask = ee.ImageCollection(
+    changeFromClasses.map(function(classId) {
+      return baselineClassification.eq(classId)
+    })
+    ).max(); // max() works as a logical OR across the imagecollection
+
+  // ************
+  // set up the logic to map over the classified monitoring collection 
+  // ************
+  // to locate the valid change event pixels per image
+  // concats 3 bands to each image of the monitoring collection
+  // e.g. 38 images with 2 bands each, becomes 38 images with 5 bands each
+
+  // ==============================================================================
+  // 2A. changeEvents LOGIC
+  // ==============================================================================
+
+  var changeEvents = classifiedMonitoringCollection.map(function(image) {
+    var currentClass = image.select("classification");
+    var currentIndex = image.select("gate_index");
+
+    // ************
+    // for each image, identify where pixels are a FROM class in the monitoring collection
+    // this describes the consistency of each pixel as a FROM class
+    var isFromClass = ee.ImageCollection(
+      changeFromClasses.map(function(classId) {
+        return currentClass.eq(classId);
+      })
+    ).max().rename("is_from_class");
+    // ************
+
+    // ************
+    // for each image, identify where pixels are a TO class in the monitoring collection
+    // this describes the consistency of each pixel as a TO class
+    var isToClass = ee.ImageCollection(
+      changeToClasses.map(function(classId) {
+        return currentClass.eq(classId);
+      })
+    ).max().rename("is_to_class");
+    // ************
+
+    // identify which pixels have changed to ChangeToClasses
+    var transitionMask = fromMask.and(isToClass).rename("transition_mask"); // using a mask allows for .and to work
+      
+    // calculate whether the index dropped by at least the threshold vs baseline
+    var deltaIndex = baselineIndex.subtract(currentIndex).rename("delta_index");
+    var deltaIndexThresholdedMask = deltaIndex.gte(indexGate.threshold).rename("delta_index_thresholded_mask"); // boolean of whether a pixel passed the evaluation
+
+    // flag where both conditions (class and index drop) are met
+    var isChangeMask = transitionMask.and(deltaIndexThresholdedMask).rename("is_change");
+      
+    // store the image_date as a band for change reporting
+    var imgMillis = ee.Image.constant(image.getNumber("system:time_start"));
+    var imgMillisGeneric = imgMillis.double();
+    
+    // build dates of all changes above the index threshold
+    var changeDateAboveThreshold = imgMillisGeneric.updateMask(isChangeMask).rename("change_date_above_threshold")
+
+    return image.addBands([isChangeMask, changeDateAboveThreshold, deltaIndexThresholdedMask, deltaIndex, isFromClass, isToClass, currentClass, transitionMask]);
+  }); // end of changeEvents function
+  // an imagecollection, each image has the six bands above
+
+  // ==============================================================================
+  // 2B. postChangeEvaluation LOGIC
+  // ==============================================================================
+
+  // get the first change date per pixel
+  var firstChangeDateAboveThreshold = changeEvents.select("change_date_above_threshold").min().rename("first_change_date_above_threshold");
+
+  // map over the change images in changeEvents a second time, to evaluate temporal consistency of the first changes
+  var postChangeEvaluation = changeEvents.map(function(image) {
+    // get the timestamp, cast to double to ensure homogeneity of types
+    var currentMillis = ee.Image.constant(image.getNumber("system:time_start")).double();
+
+    // create a temporal window mask
+    // pixel has a value of 1 if it has a change that is the first change or is afterwards
+    var isAfterFirstChange = currentMillis.gte(firstChangeDateAboveThreshold);
+    var isPostFCD = isAfterFirstChange.rename("post_fcd"); // boolean (1, 0) indicating whether the pixel is post-FCD
+    var isChange = image.select("is_change") // 1 for change, 0 for no change
+    // here find out if masked, then unmasked and eq
+    // var isPostFCDOccluded = isPostFCD.mask().unmask(0).eq(0).rename("post_fcd_occluded") 
+
+    var isOccluded = image.select("classification").mask().not();
+    
+    // combine first change date with whether was occluded
+    // we unmask isAfterFirstChange to 0. If a pixel never had a first change, 
+    // it cannot have post-FCD occlusions, so we force it to 0 instead of leaving it masked
+    var isPostFCDOccluded = isOccluded.and(isAfterFirstChange.unmask(0)).rename("post_fcd_occluded");
+
+    // a pixel had a change after after FCD
+    var subsequentChange = isChange.and(isAfterFirstChange).rename("post_fcd_change")
+
+    // a pixel did not have a new change after a FCD
+    var isNotChange = isChange.not(); // turns 0s (no change) to 1s and vice versa - 1s (change) to 0s
+    var subsequentNonChange = isNotChange.and(isAfterFirstChange).rename("post_fcd_nochange");
+
+    // return an imagecollection of images with two bands each, of subsquent change and non-change
+    return image.addBands([subsequentChange, subsequentNonChange, isPostFCD, isPostFCDOccluded]);
+  });
+  
+  // ==============================================================================
+  // 3. COMPILING CHANGE REPORT LAYERS
+  // ==============================================================================
+
+  // LAYER 0: count the number of images within the collection
+  var availableImageCount = ee.Image(
+    ee.Image.constant(classifiedMonitoringCollection.size()))
+    .clip(aoi)
+    .rename("available_image_count");
+    
+  // LAYER 1: count the number of occluded images per pixel
+  var occludedCount = classifiedMonitoringCollection.map(function(image) {
+    var isOccluded = image.select("classification").mask().unmask(0).eq(0);
+    // .mask() returns a 1 for valid pixels and is masked for cloudy pixels
+    // unmask(0) converts these cloudy pixels to 0, but it also respects the image footprint
+    // and leaves pixels outside of the image boundary fully masked
+    // .eq(0) turns the 0s (clouds) into 1s so these can be summed and counted
+    return isOccluded.rename("occluded_count");
+  }).sum();
+
+  // LAYER 2: class change detection count - how many times a pixel changed from a FROM class to a TO class
+  var classChangeDetectionCount = changeEvents.select("is_change").sum().rename("total_changes")
+
+  // LAYER 3: firstChangeDate (FCD) and Combined Alert Detection (changes that pass the index threshold)
+  // firstChangeDateAboveThreshold computed above
+
+  // LAYER 4: Post-FCD Combined Alert Count (count of changes that pass the index threshold since the first change date)
+  // get the counts by summing the post-FCD change
+  var postFCDChangeCount = postChangeEvaluation.select("post_fcd_change").sum().rename("post_fcd_change_count");
+
+  // LAYER 5: Post-FCD Combined Non-Alert Count (count of no changes since the first change date)
+  // get the counts by summing the post-FCD no changes
+  var postFCDNoChangeCount = postChangeEvaluation.select("post_fcd_nochange").sum().rename("post_fcd_nochange_count");
+
+  // LAYER 6: Post-FCD Occluded Image Count
+  var postFCDOccludedCount = postChangeEvaluation.select("post_fcd_occluded").sum().rename("post_fcd_occluded_count");
+
+  // LAYER 7: Post-FCD Valid Image Count
+  var postFCDValidImageCount = postFCDChangeCount.add(postFCDNoChangeCount).rename("post_fcd_valid_image_count");
+
+  // LAYER 8: Post-FCD Change Detection Repeatability
+  var postFCDChangeDetectionRepeatability = postFCDChangeCount
+    .divide(postFCDValidImageCount)
+    .multiply(100)
+    .rename("post_fcd_change_repeatability_pct");
+
+  // LAYER 9: Binary time-series decision
+  var binaryTimeSeriesDecision = postFCDChangeDetectionRepeatability.gte(percentageProbabilityThreshold)
+    .and(postFCDChangeCount.gte(minRequiredValidatedDetectionsThreshold))
+    .rename("binary_timeseries_decision");
+
+  // LAYER 10: FCD Decision Map
+  var FCDDecisionMap = firstChangeDateAboveThreshold
+    .updateMask(binaryTimeSeriesDecision)
+    .rename("fcd_decision_map");
+
+  // LAYER 11: index-drop only change detection count
+  var deltaIndexChangeDetectionCount = changeEvents
+    .select("delta_index_thresholded_mask")
+    .sum()
+    .rename("delta_index_change_count");
+
+  // LAYER 12: Binary index-drop Alert Decision Map
+  var binaryDeltaIndexDecisionMap = deltaIndexChangeDetectionCount.gte(indexGate.minRequiredDeltaIndexDetectionsThreshold)
+    .rename("binary_delta_index_decision_map");
+
+  // LAYER 13: Binary dClass Alert Decision Map // class-only, ignoring the index gate
+  var classChangeDetectionCountNoGate = changeEvents.select("transition_mask").sum().rename("total_class_changes_no_gate")
+
+  var binaryDeltaClassDecisionMap = classChangeDetectionCountNoGate.gte(minRequiredClassifierDetectionsThreshold)
+    .rename("binary_delta_class_decision_map");
+
+  // LAYER 14: Combined index-drop & dClass Decision Map
+  var binaryCombinedDeltaDecisionMap = binaryDeltaClassDecisionMap.and(binaryDeltaIndexDecisionMap)
+    .rename("binary_combined_delta_decision_map");
+
+  // LAYER 15: count the number of pixels that were a FROM class
+  // "counts" by summing across the collection https://developers.google.com/earth-engine/apidocs/ee-imagecollection-sum
+  var fromClassCount = changeEvents.select("is_from_class").sum().rename("from_class_count");
+  // ************
+
+  // LAYER 16: count the number of pixels that were a TO class
+  var toClassCount = changeEvents.select("is_to_class").sum().rename("to_class_count");
+
+  // LAYER 17: L15.and(L16) Binary Decision Thresholds on FROM and TO classification counts
+  var binaryDecisionFromToMap = fromClassCount.gte(minRequiredFromDetectionsThreshold)
+    .and(toClassCount.gte(minRequiredToDetectionsThreshold))
+    .rename("binary_decision_from_to_map");
+
+  return ee.Image([
+    availableImageCount,
+    occludedCount,
+    classChangeDetectionCount,
+    firstChangeDateAboveThreshold,
+    postFCDChangeCount,
+    postFCDNoChangeCount,
+    postFCDOccludedCount,
+    postFCDValidImageCount,
+    postFCDChangeDetectionRepeatability,
+    binaryTimeSeriesDecision,
+    FCDDecisionMap,
+    deltaIndexChangeDetectionCount,
+    binaryDeltaIndexDecisionMap,
+    binaryDeltaClassDecisionMap,
+    binaryCombinedDeltaDecisionMap,
+    fromClassCount,
+    toClassCount,
+    binaryDecisionFromToMap
+  ]);
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/bands.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/bands.js
@@ -1,0 +1,29 @@
+export const getAvailableBands = () => ({
+    available_image_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Available image count'},
+    occluded_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Occluded image count'},
+    total_changes: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Total changes'},
+    first_change_date_above_threshold: {dataType: {precision: 'int', min: 0, max: 2000000000000}, label: 'First change date (ms)'},
+    post_fcd_change_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Post-FCD change count'},
+    post_fcd_nochange_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Post-FCD no-change count'},
+    post_fcd_occluded_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Post-FCD occluded count'},
+    post_fcd_valid_image_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Post-FCD valid image count'},
+    post_fcd_change_repeatability_pct: {dataType: {precision: 'float', min: 0, max: 100}, label: 'Post-FCD change repeatability (%)'},
+    binary_timeseries_decision: {dataType: {precision: 'int', min: 0, max: 1}, label: 'Binary time-series decision'},
+    fcd_decision_map: {dataType: {precision: 'float'}, label: 'FCD decision map'},
+    delta_index_change_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'Index-drop count'},
+    binary_delta_index_decision_map: {dataType: {precision: 'int', min: 0, max: 1}, label: 'Binary index-drop decision'},
+    binary_delta_class_decision_map: {dataType: {precision: 'int', min: 0, max: 1}, label: 'Binary dClass decision'},
+    binary_combined_delta_decision_map: {dataType: {precision: 'int', min: 0, max: 1}, label: 'Binary combined decision'},
+    from_class_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'From-class count'},
+    to_class_count: {dataType: {precision: 'int', min: 0, max: 999}, label: 'To-class count'},
+    binary_decision_from_to_map: {dataType: {precision: 'int', min: 0, max: 1}, label: 'Binary from-to decision'}
+})
+
+export const getGroupedBandOptions = () => {
+    const bands = getAvailableBands()
+    return [
+        Object
+            .keys(bands)
+            .map(band => ({value: band, ...bands[band]}))
+    ]
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/dates/dates.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/dates/dates.jsx
@@ -1,0 +1,150 @@
+import moment from 'moment'
+import React from 'react'
+
+import {withRecipe} from '~/app/home/body/process/recipeContext'
+import {RecipeFormPanel, recipeFormPanel} from '~/app/home/body/process/recipeFormPanel'
+import {compose} from '~/compose'
+import {selectFrom} from '~/stateUtils'
+import {msg} from '~/translate'
+import {Form} from '~/widget/form'
+import {Layout} from '~/widget/layout'
+import {Panel} from '~/widget/panel/panel'
+import {Widget} from '~/widget/widget'
+
+import styles from './dates.module.css'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+const MIN_DATE = '1982-08-22'
+
+const fields = {
+    baselineStart: new Form.Field()
+        .notBlank('process.pyeoAlerts.panel.dates.form.baselineStart.required')
+        .date(DATE_FORMAT, 'process.pyeoAlerts.panel.dates.form.baselineStart.malformed'),
+    baselineEnd: new Form.Field()
+        .notBlank('process.pyeoAlerts.panel.dates.form.baselineEnd.required')
+        .date(DATE_FORMAT, 'process.pyeoAlerts.panel.dates.form.baselineEnd.malformed'),
+    monitoringStart: new Form.Field()
+        .notBlank('process.pyeoAlerts.panel.dates.form.monitoringStart.required')
+        .date(DATE_FORMAT, 'process.pyeoAlerts.panel.dates.form.monitoringStart.malformed'),
+    monitoringEnd: new Form.Field()
+        .notBlank('process.pyeoAlerts.panel.dates.form.monitoringEnd.required')
+        .date(DATE_FORMAT, 'process.pyeoAlerts.panel.dates.form.monitoringEnd.malformed')
+}
+
+const constraints = {
+    baselineStartBeforeEnd: new Form.Constraint(['baselineStart', 'baselineEnd'])
+        .skip(({baselineEnd}) => !baselineEnd)
+        .predicate(({baselineStart, baselineEnd}) => baselineStart < baselineEnd,
+            'process.pyeoAlerts.panel.dates.form.baselineStart.beforeEnd'),
+    monitoringStartBeforeEnd: new Form.Constraint(['monitoringStart', 'monitoringEnd'])
+        .skip(({monitoringEnd}) => !monitoringEnd)
+        .predicate(({monitoringStart, monitoringEnd}) => monitoringStart < monitoringEnd,
+            'process.pyeoAlerts.panel.dates.form.monitoringStart.beforeEnd'),
+    baselineBeforeMonitoring: new Form.Constraint(['baselineEnd', 'monitoringStart'])
+        .skip(({baselineEnd, monitoringStart}) => !baselineEnd || !monitoringStart)
+        .predicate(({baselineEnd, monitoringStart}) => baselineEnd <= monitoringStart,
+            'process.pyeoAlerts.panel.dates.form.baselineEnd.beforeMonitoring')
+}
+
+const mapRecipeToProps = recipe => ({
+    derived: selectFrom(recipe, 'model.dates.derived')
+})
+
+class _Dates extends React.Component {
+    render() {
+        return (
+            <RecipeFormPanel
+                className={styles.panel}
+                placement='bottom-right'>
+                <Panel.Header
+                    icon='calendar'
+                    title={msg('process.pyeoAlerts.panel.dates.title')}/>
+                <Panel.Content>
+                    <Layout>
+                        {this.props.derived ? this.renderDerivedInfo() : this.renderBaseline()}
+                        {this.renderMonitoring()}
+                    </Layout>
+                </Panel.Content>
+                <Form.PanelButtons/>
+            </RecipeFormPanel>
+        )
+    }
+
+    renderDerivedInfo() {
+        const {inputs: {baselineStart, baselineEnd}} = this.props
+        return (
+            <Form.FieldSet
+                label={msg('process.pyeoAlerts.panel.dates.form.baseline.label')}
+                layout='horizontal'>
+                <Widget
+                    label={msg('process.pyeoAlerts.panel.dates.form.baselineStart.label')}
+                    disabled>
+                    {baselineStart.value}
+                </Widget>
+                <Widget
+                    label={msg('process.pyeoAlerts.panel.dates.form.baselineEnd.label')}
+                    disabled>
+                    {baselineEnd.value}
+                </Widget>
+            </Form.FieldSet>
+        )
+    }
+
+    renderBaseline() {
+        const {inputs: {baselineStart, baselineEnd, monitoringStart}} = this.props
+        return (
+            <Form.FieldSet
+                label={msg('process.pyeoAlerts.panel.dates.form.baseline.label')}
+                layout='horizontal'
+                errorMessage={[baselineStart, baselineEnd, 'baselineStartBeforeEnd']}>
+                <Form.DatePicker
+                    label={msg('process.pyeoAlerts.panel.dates.form.baselineStart.label')}
+                    input={baselineStart}
+                    startDate={MIN_DATE}
+                    endDate={baselineEnd.value || moment()}
+                />
+                <Form.DatePicker
+                    label={msg('process.pyeoAlerts.panel.dates.form.baselineEnd.label')}
+                    input={baselineEnd}
+                    startDate={baselineStart.value || MIN_DATE}
+                    endDate={monitoringStart.value || moment()}
+                />
+            </Form.FieldSet>
+        )
+    }
+
+    renderMonitoring() {
+        const {inputs: {baselineEnd, monitoringStart, monitoringEnd}} = this.props
+        return (
+            <Form.FieldSet
+                label={msg('process.pyeoAlerts.panel.dates.form.monitoring.label')}
+                layout='horizontal'
+                errorMessage={[
+                    monitoringStart,
+                    monitoringEnd,
+                    'monitoringStartBeforeEnd',
+                    'baselineBeforeMonitoring'
+                ]}>
+                <Form.DatePicker
+                    label={msg('process.pyeoAlerts.panel.dates.form.monitoringStart.label')}
+                    input={monitoringStart}
+                    startDate={baselineEnd.value || MIN_DATE}
+                    endDate={monitoringEnd.value || moment()}
+                    disabled={this.props.derived}
+                />
+                <Form.DatePicker
+                    label={msg('process.pyeoAlerts.panel.dates.form.monitoringEnd.label')}
+                    input={monitoringEnd}
+                    startDate={monitoringStart.value || baselineEnd.value || MIN_DATE}
+                    endDate={moment()}
+                />
+            </Form.FieldSet>
+        )
+    }
+}
+
+export const Dates = compose(
+    _Dates,
+    withRecipe(mapRecipeToProps),
+    recipeFormPanel({id: 'dates', fields, constraints})
+)

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/dates/dates.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/dates/dates.module.css
@@ -1,0 +1,4 @@
+.panel {
+    max-width: 20rem;
+    min-height: 20rem;
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/options/options.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/options/options.jsx
@@ -1,0 +1,166 @@
+import React from 'react'
+
+import {getIndexesForBands} from '~/app/home/body/process/recipe/opticalMosaic/indexes'
+import {getDataSetBands} from '~/app/home/body/process/recipe/opticalMosaic/sources'
+import {RecipeFormPanel, recipeFormPanel} from '~/app/home/body/process/recipeFormPanel'
+import {compose} from '~/compose'
+import {selectFrom} from '~/stateUtils'
+import {msg} from '~/translate'
+import {Form} from '~/widget/form'
+import {Layout} from '~/widget/layout'
+import {Panel} from '~/widget/panel/panel'
+
+import styles from './options.module.css'
+
+// V1: land-change-meaningful normalized-difference indices (all bounded [-1, 1],
+// where a *drop* vs. baseline signals disturbance). Source-filtered at render.
+const GATE_INDEXES = ['ndvi', 'ndmi', 'nbr']
+
+const fields = {
+    minConsecutiveDetections: new Form.Field()
+        .notBlank()
+        .int(),
+    useIndexGate: new Form.Field(),
+    gateIndex: new Form.Field()
+        .skip((_v, {useIndexGate}) => !useIndexGate)
+        .notBlank('process.pyeoAlerts.panel.options.form.gateIndex.required'),
+    gateThreshold: new Form.Field()
+        .skip((_v, {useIndexGate}) => !useIndexGate)
+        .notBlank('process.pyeoAlerts.panel.options.form.gateThreshold.required')
+}
+
+const mapRecipeToProps = recipe => ({
+    dataSets: selectFrom(recipe, 'model.sources.dataSets'),
+    classificationBands: selectFrom(recipe, 'ui.classificationBands')
+})
+
+class _Options extends React.Component {
+    render() {
+        return (
+            <RecipeFormPanel
+                className={styles.panel}
+                placement='bottom-right'>
+                <Panel.Header
+                    icon='shuffle'
+                    title={msg('process.pyeoAlerts.panel.options.title')}/>
+                <Panel.Content>
+                    {this.renderContent()}
+                </Panel.Content>
+                <Form.PanelButtons/>
+            </RecipeFormPanel>
+        )
+    }
+
+    componentDidMount() {
+        this.forceGateOffIfUnavailable()
+    }
+
+    componentDidUpdate() {
+        this.forceGateOffIfUnavailable()
+    }
+
+    // With no computable index, force the gate off so a stale/default "on" can't require an index
+    // the source can't produce — the toggle is also disabled in renderContent().
+    forceGateOffIfUnavailable() {
+        const {inputs: {useIndexGate}} = this.props
+        if (useIndexGate.value && !this.availableIndexes().length) {
+            useIndexGate.set(false)
+        }
+    }
+
+    renderContent() {
+        const {inputs: {useIndexGate, minConsecutiveDetections}} = this.props
+        const gateAvailable = this.availableIndexes().length > 0
+        return (
+            <Layout>
+                <Form.Buttons
+                    label={msg('process.pyeoAlerts.panel.options.form.useIndexGate.label')}
+                    tooltip={msg(gateAvailable
+                        ? 'process.pyeoAlerts.panel.options.form.useIndexGate.tooltip'
+                        : 'process.pyeoAlerts.panel.options.form.useIndexGate.unavailable')}
+                    input={useIndexGate}
+                    options={[
+                        {value: false, label: msg('process.pyeoAlerts.panel.options.form.useIndexGate.off')},
+                        {value: true, label: msg('process.pyeoAlerts.panel.options.form.useIndexGate.on')}
+                    ]}
+                    disabled={!gateAvailable}
+                />
+                {useIndexGate.value && gateAvailable ? this.renderIndexGate() : null}
+                <Form.Slider
+                    label={msg('process.pyeoAlerts.panel.options.form.minConsecutiveDetections.label')}
+                    tooltip={msg('process.pyeoAlerts.panel.options.form.minConsecutiveDetections.tooltip')}
+                    input={minConsecutiveDetections}
+                    minValue={1}
+                    maxValue={10}
+                    ticks={[1, 2, 3, 5, 10]}
+                    info={value => msg('process.pyeoAlerts.panel.options.form.minConsecutiveDetections.value', {value})}
+                />
+            </Layout>
+        )
+    }
+
+    renderIndexGate() {
+        const {inputs: {gateIndex, gateThreshold}} = this.props
+        return (
+            <Layout>
+                <Form.Combo
+                    label={msg('process.pyeoAlerts.panel.options.form.gateIndex.label')}
+                    tooltip={msg('process.pyeoAlerts.panel.options.form.gateIndex.tooltip')}
+                    input={gateIndex}
+                    options={this.indexOptions()}
+                />
+                <Form.Slider
+                    label={msg('process.pyeoAlerts.panel.options.form.gateThreshold.label')}
+                    tooltip={msg('process.pyeoAlerts.panel.options.form.gateThreshold.tooltip')}
+                    input={gateThreshold}
+                    minValue={0}
+                    maxValue={1}
+                    decimals={2}
+                    ticks={[0, 0.25, 0.5, 0.75, 1]}
+                    info={value => msg('process.pyeoAlerts.panel.options.form.gateThreshold.value', {value})}
+                />
+            </Layout>
+        )
+    }
+
+    // Gate indexes computable on BOTH the classification's baseline imagery and the monitoring
+    // datasets — the gate runs on both, so a band missing from either rules the index out.
+    // classificationBands undefined ⇒ not resolved yet: fall back so we don't pre-disable.
+    availableIndexes() {
+        const {dataSets, classificationBands} = this.props
+        const classificationIndexes = classificationBands
+            ? getIndexesForBands(classificationBands)
+            : GATE_INDEXES
+        const dataSetIndexes = dataSets && Object.keys(dataSets).length
+            ? getIndexesForBands(getDataSetBands({model: {sources: {dataSets}}}))
+            : GATE_INDEXES
+        return GATE_INDEXES.filter(index =>
+            classificationIndexes.includes(index) && dataSetIndexes.includes(index)
+        )
+    }
+
+    indexOptions() {
+        return this.availableIndexes().map(index => ({value: index, label: index.toUpperCase()}))
+    }
+}
+
+const valuesToModel = values => ({
+    minConsecutiveDetections: Number(values.minConsecutiveDetections),
+    indexGate: values.useIndexGate
+        ? {index: values.gateIndex, threshold: Number(values.gateThreshold)}
+        : undefined
+})
+
+const modelToValues = model => ({
+    minConsecutiveDetections: model.minConsecutiveDetections || 2,
+    useIndexGate: !!model.indexGate,
+    gateIndex: (model.indexGate && model.indexGate.index) || 'ndvi',
+    gateThreshold: model.indexGate && model.indexGate.threshold !== undefined
+        ? model.indexGate.threshold
+        : 0.20
+})
+
+export const Options = compose(
+    _Options,
+    recipeFormPanel({id: 'pyeoAlertsOptions', fields, mapRecipeToProps, modelToValues, valuesToModel})
+)

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/options/options.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/options/options.module.css
@@ -1,0 +1,3 @@
+.panel {
+    width: 32rem;
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/pyeoAlertsToolbar.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/pyeoAlertsToolbar.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+
+import {setInitialized} from '~/app/home/body/process/recipe'
+import {Aoi} from '~/app/home/body/process/recipe/mosaic/panels/aoi/aoi'
+import {createCompositeOptions} from '~/app/home/body/process/recipe/opticalMosaic/panels/compositeOptions/compositeOptions'
+import {withRecipe} from '~/app/home/body/process/recipeContext'
+import {compose} from '~/compose'
+import {selectFrom} from '~/stateUtils'
+import {msg} from '~/translate'
+import {PanelWizard} from '~/widget/panelWizard'
+import {Toolbar} from '~/widget/toolbar/toolbar'
+
+import {RetrieveButton} from '../../retrieveButton'
+import {Dates} from './dates/dates'
+import {Options} from './options/options'
+import styles from './pyeoAlertsToolbar.module.css'
+import {Retrieve} from './retrieve/retrieve'
+import {Sources} from './sources/sources'
+
+// Shared Pre-process ("PRC") panel — NOT forCollection: we build a baseline
+// composite and need compose/cloudBuffer/holes/filters editable.
+const PreProcess = createCompositeOptions({id: 'options'})
+
+const mapRecipeToProps = recipe => ({
+    recipeId: recipe.id,
+    initialized: selectFrom(recipe, 'ui.initialized'),
+    classification: selectFrom(recipe, 'model.sources.classification')
+})
+
+class _PyeoAlertsToolbar extends React.Component {
+    render() {
+        const {recipeId, initialized, classification} = this.props
+        return (
+            <PanelWizard
+                panels={['aoi', 'sources', 'dates']}
+                initialized={initialized}
+                onDone={() => setInitialized(recipeId)}>
+
+                <Retrieve/>
+
+                <Aoi/>
+                <Sources/>
+                <Dates/>
+                <PreProcess title={msg('process.timeSeries.panel.preprocess.title')}/>
+                <Options/>
+
+                <Toolbar
+                    vertical
+                    placement='top-right'
+                    className={styles.top}>
+                    <RetrieveButton disabled={!classification}/>
+                </Toolbar>
+                <Toolbar
+                    vertical
+                    placement='bottom-right'
+                    className={styles.bottom}>
+                    <Toolbar.ActivationButton
+                        id='aoi'
+                        label={msg('process.mosaic.panel.areaOfInterest.button')}
+                        tooltip={msg('process.mosaic.panel.areaOfInterest.tooltip')}
+                        disabled={!initialized}
+                        panel/>
+                    <Toolbar.ActivationButton
+                        id='sources'
+                        label={msg('process.pyeoAlerts.panel.sources.button')}
+                        tooltip={msg('process.pyeoAlerts.panel.sources.tooltip')}
+                        disabled={!initialized}
+                        panel/>
+                    <Toolbar.ActivationButton
+                        id='dates'
+                        label={msg('process.pyeoAlerts.panel.dates.button')}
+                        tooltip={msg('process.pyeoAlerts.panel.dates.tooltip')}
+                        disabled={!initialized}
+                        panel/>
+                    <Toolbar.ActivationButton
+                        id='options'
+                        label={msg('process.timeSeries.panel.preprocess.button')}
+                        tooltip={msg('process.timeSeries.panel.preprocess.tooltip')}
+                        disabled={!initialized}
+                        panel/>
+                    <Toolbar.ActivationButton
+                        id='pyeoAlertsOptions'
+                        label={msg('process.pyeoAlerts.panel.options.button')}
+                        tooltip={msg('process.pyeoAlerts.panel.options.tooltip')}
+                        disabled={!initialized}
+                        panel/>
+                </Toolbar>
+            </PanelWizard>
+        )
+    }
+}
+
+export const PyeoAlertsToolbar = compose(
+    _PyeoAlertsToolbar,
+    withRecipe(mapRecipeToProps)
+)

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/pyeoAlertsToolbar.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/pyeoAlertsToolbar.module.css
@@ -1,0 +1,16 @@
+.top, .bottom {
+    --look-default-h: 37;
+    --look-default-s: 27%;
+    --look-default-l: 25%;
+    --look-default-a: .9;
+
+    --look-highlight-h: 40;
+    --look-highlight-s: 8%;
+    --look-highlight-l: 15%;
+    --look-highlight-a: .95;
+
+    --look-disabled-h: 37;
+    --look-disabled-s: 10%;
+    --look-disabled-l: 20%;
+    --look-disabled-a: .9;
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/retrieve/retrieve.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/retrieve/retrieve.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import {MosaicRetrievePanel} from '~/app/home/body/process/recipe/mosaic/panels/retrieve/retrievePanel'
+import {getGroupedBandOptions} from '~/app/home/body/process/recipe/pyeoAlerts/bands'
+import {RecipeActions} from '~/app/home/body/process/recipe/pyeoAlerts/pyeoAlertsRecipe'
+import {withRecipe} from '~/app/home/body/process/recipeContext'
+import {compose} from '~/compose'
+
+const mapRecipeToProps = recipe => ({recipe})
+
+class _Retrieve extends React.Component {
+    render() {
+        return (
+            <MosaicRetrievePanel
+                bandOptions={this.bandOptions()}
+                defaultScale={10}
+                toSepal
+                toEE
+                toDrive
+                onRetrieve={retrieveOptions => this.retrieve(retrieveOptions)}
+            />
+        )
+    }
+
+    bandOptions() {
+        return getGroupedBandOptions()
+    }
+
+    retrieve(retrieveOptions) {
+        const {recipeId} = this.props
+        return RecipeActions(recipeId).retrieve(retrieveOptions)
+    }
+}
+
+export const Retrieve = compose(
+    _Retrieve,
+    withRecipe(mapRecipeToProps)
+)
+
+Retrieve.propTypes = {}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/sources/sources.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/sources/sources.jsx
@@ -1,0 +1,456 @@
+import _ from 'lodash'
+import moment from 'moment'
+import React from 'react'
+import {Subject, takeUntil} from 'rxjs'
+
+import api from '~/apiRegistry'
+import {getDataSetBands, getDataSetOptions as opticalDataSetOptions} from '~/app/home/body/process/recipe/opticalMosaic/sources'
+import {recipeAccess} from '~/app/home/body/process/recipeAccess'
+import {withRecipe} from '~/app/home/body/process/recipeContext'
+import {RecipeFormPanel, recipeFormPanel} from '~/app/home/body/process/recipeFormPanel'
+import {getRecipeType} from '~/app/home/body/process/recipeTypeRegistry'
+import {compose} from '~/compose'
+import {connect} from '~/connect'
+import {toSources} from '~/sources'
+import {selectFrom} from '~/stateUtils'
+import {select} from '~/store'
+import {msg} from '~/translate'
+import {Form} from '~/widget/form'
+import {Icon} from '~/widget/icon'
+import {Layout} from '~/widget/layout'
+import {NoData} from '~/widget/noData'
+import {Notifications} from '~/widget/notifications'
+import {Panel} from '~/widget/panel/panel'
+
+import toDateString from '../../toDateString'
+import styles from './sources.module.css'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+const fields = {
+    classification: new Form.Field(),
+    dataSets: new Form.Field()
+        .notEmpty('process.pyeoAlerts.panel.sources.form.dataSets.required'),
+    cloudPercentageThreshold: new Form.Field(),
+    changeFromClasses: new Form.Field()
+        .notEmpty('process.pyeoAlerts.panel.sources.form.changeFromClasses.required'),
+    changeToClasses: new Form.Field()
+        .notEmpty('process.pyeoAlerts.panel.sources.form.changeToClasses.required')
+        .predicate(
+            (toClasses, {changeFromClasses}) => {
+                const overlap = (toClasses || []).filter(c => (changeFromClasses || []).includes(c))
+                return overlap.length === 0
+            },
+            'process.pyeoAlerts.panel.sources.form.changeToClasses.overlap'
+        )
+}
+
+const mapStateToProps = () => ({
+    recipes: select('process.recipes') || []
+})
+
+const mapRecipeToProps = recipe => ({
+    dates: selectFrom(recipe, 'model.dates'),
+    classificationLegend: selectFrom(recipe, 'ui.classificationLegend')
+})
+
+class _Sources extends React.Component {
+    cancel$ = new Subject()
+    state = {classificationError: null}
+    // Pre-process/Dates params derived from the classification, staged on select and
+    // committed on Apply — selecting a classification must never mutate the recipe or map.
+    pendingModel = null
+    // Whether the user manually chose optical datasets; if so we keep them across classifications.
+    dataSetsTouched = false
+
+    componentDidMount() {
+        // A saved recipe already carries the user's datasets — treat them as user-owned so a
+        // later classification change won't overwrite them. A fresh recipe starts empty and
+        // follows the classification's native default until the user intervenes.
+        const {model} = this.props
+        this.dataSetsTouched = !!(model && model.dataSets && Object.keys(model.dataSets).length)
+        // Load the legend for an already-selected classification (edit of a saved recipe) so the
+        // From/To options render. No prefill — that only happens on a user change.
+        this.syncLegendFromModel()
+    }
+
+    componentWillUnmount() {
+        this.cancel$.next()
+        this.cancel$.complete()
+    }
+
+    render() {
+        return (
+            <RecipeFormPanel
+                className={styles.panel}
+                placement='bottom-right'
+                onApply={() => this.onApply()}
+                onCancel={() => this.onCancel()}>
+                <Panel.Header icon='cog' title={msg('process.pyeoAlerts.panel.sources.title')}/>
+                <Panel.Content>
+                    <Layout>
+                        {this.renderClassification()}
+                        {this.renderDataSets()}
+                        {this.renderCloudPercentageThreshold()}
+                        {this.renderChangeClasses()}
+                    </Layout>
+                </Panel.Content>
+                <Form.PanelButtons/>
+            </RecipeFormPanel>
+        )
+    }
+
+    isLoading() {
+        const {stream} = this.props
+        return stream('LOAD_CLASSIFICATION').active
+            || stream('LOAD_MOSAIC').active
+            || stream('LOAD_ASSET_METADATA').active
+    }
+
+    hasClasses() {
+        // A valid, loaded classification is one that produced a legend. An invalid
+        // classification (error, legend cleared) leaves the downstream controls disabled.
+        return !!this.props.classificationLegend
+    }
+
+    renderClassification() {
+        const {recipes, inputs: {classification}} = this.props
+        const options = recipes
+            .filter(({type}) => type === 'CLASSIFICATION')
+            .map(recipe => ({value: recipe.id, label: recipe.name}))
+        return (
+            <Form.Combo
+                label={msg('process.pyeoAlerts.panel.sources.form.classification.label')}
+                tooltip={msg('process.pyeoAlerts.panel.sources.form.classification.tooltip')}
+                placeholder={msg('process.pyeoAlerts.panel.sources.form.classification.placeholder')}
+                options={options}
+                input={classification}
+                busyMessage={this.isLoading()}
+                errorMessage={this.state.classificationError}
+                onChange={option => this.onClassificationSelected(option)}
+            />
+        )
+    }
+
+    renderDataSets() {
+        const {dates, inputs: {dataSets}} = this.props
+        return (
+            <Form.Buttons
+                label={msg('process.pyeoAlerts.panel.sources.form.dataSets.label')}
+                tooltip={msg('process.pyeoAlerts.panel.sources.form.dataSets.tooltip')}
+                input={dataSets}
+                options={opticalDataSetOptions({...dates})}
+                multiple
+                disabled={!this.hasClasses()}
+                onChange={() => {this.dataSetsTouched = true}}
+            />
+        )
+    }
+
+    renderCloudPercentageThreshold() {
+        const {inputs: {cloudPercentageThreshold}} = this.props
+        return (
+            <Form.Slider
+                label={msg('process.pyeoAlerts.panel.sources.form.cloudPercentageThreshold.label')}
+                tooltip={msg('process.pyeoAlerts.panel.sources.form.cloudPercentageThreshold.tooltip')}
+                input={cloudPercentageThreshold}
+                minValue={0}
+                maxValue={100}
+                ticks={[0, 10, 25, 50, 75, 90, 100]}
+                range='low'
+                info={value =>
+                    msg('process.pyeoAlerts.panel.sources.form.cloudPercentageThreshold.value', {value})
+                }
+                disabled={!this.hasClasses()}
+            />
+        )
+    }
+
+    renderChangeClasses() {
+        return (
+            <div className={styles.changeClasses}>
+                {this.renderChangeClassesContent()}
+            </div>
+        )
+    }
+
+    renderChangeClassesContent() {
+        const {inputs: {changeFromClasses, changeToClasses}, classificationLegend} = this.props
+        if (this.isLoading()) {
+            return (
+                <div className={styles.changeClassesMessage}>
+                    <Icon name='spinner'/>
+                </div>
+            )
+        }
+        const entries = (classificationLegend && classificationLegend.entries) || []
+        if (!entries.length) {
+            return (
+                <div className={styles.changeClassesMessage}>
+                    <NoData message={msg('process.pyeoAlerts.panel.sources.form.changeClasses.noClassification')}/>
+                </div>
+            )
+        }
+        const fromValues = changeFromClasses.value || []
+        const toValues = changeToClasses.value || []
+        const fromOptions = entries.map(({value, label, color}) => ({value, label, color, disabled: toValues.includes(value)}))
+        const toOptions = entries.map(({value, label, color}) => ({value, label, color, disabled: fromValues.includes(value)}))
+        return (
+            <Layout>
+                <Form.Buttons
+                    label={msg('process.pyeoAlerts.panel.sources.form.changeFromClasses.label')}
+                    tooltip={msg('process.pyeoAlerts.panel.sources.form.changeFromClasses.tooltip')}
+                    input={changeFromClasses}
+                    options={fromOptions}
+                    multiple
+                />
+                <Form.Buttons
+                    label={msg('process.pyeoAlerts.panel.sources.form.changeToClasses.label')}
+                    tooltip={msg('process.pyeoAlerts.panel.sources.form.changeToClasses.tooltip')}
+                    input={changeToClasses}
+                    options={toOptions}
+                    multiple
+                />
+            </Layout>
+        )
+    }
+
+    // ---- live classification metadata load (was the headless ClassificationSync) ----
+
+    // Mount / Cancel: reflect the committed classification — legend only, never a prefill.
+    syncLegendFromModel() {
+        const {model} = this.props
+        const id = model && model.classification
+        this.startLoad(id)
+        if (id) {
+            this.loadClassification(id, false)
+        }
+    }
+
+    // User picked a classification: load its legend and stage derived params (pending Apply).
+    onClassificationSelected(option) {
+        const id = option && option.value
+        if (id === this.loadedClassificationId) {
+            return
+        }
+        this.startLoad(id)
+        if (id) {
+            this.loadClassification(id, true)
+        } else {
+            // Cleared selection — drop any staged From/To so nothing dangles.
+            const {inputs} = this.props
+            inputs.changeFromClasses.set([])
+            inputs.changeToClasses.set([])
+        }
+    }
+
+    // Reset the load guard/stream and clear staged state before (re)loading a classification.
+    startLoad(id) {
+        this.loadedClassificationId = id
+        this.cancel$.next()
+        this.cancel$ = new Subject()
+        this.pendingModel = null
+        this.setState({classificationError: null})
+        if (!id) {
+            this.setLegend(undefined)
+            this.setClassificationBands(undefined)
+        }
+    }
+
+    loadClassification(id, prefill) {
+        const {stream, loadRecipe$} = this.props
+        stream('LOAD_CLASSIFICATION',
+            loadRecipe$(id).pipe(takeUntil(this.cancel$)),
+            classification => this.onClassification(classification, prefill),
+            error => Notifications.error({message: msg('process.pyeoAlerts.classification.loadError'), error})
+        )
+    }
+
+    onClassification(classification, prefill) {
+        // Always resolve the classification's input bands (drives the Options index-gate guard);
+        // only a user selection (prefill) stages derived Pre-process/Dates params.
+        if (prefill) {
+            const {inputs} = this.props
+            inputs.changeFromClasses.set([])
+            inputs.changeToClasses.set([])
+        }
+        const images = (classification.model.inputImagery && classification.model.inputImagery.images) || []
+        if (images.length !== 1) {
+            this.setClassificationBands(undefined)
+            if (prefill) {
+                this.setClassificationError('process.pyeoAlerts.classification.singleInputRequired', {clearLegend: true})
+            } else {
+                this.setLegend(classification.model.legend)
+            }
+            return
+        }
+        this.setLegend(classification.model.legend)
+        const input = images[0]
+        if (input.type === 'RECIPE_REF') {
+            this.loadInputRecipeRef(input, prefill)
+        } else if (input.type === 'ASSET') {
+            this.loadInputAsset(input, prefill)
+        } else {
+            this.setClassificationBands(undefined)
+            if (prefill) {
+                this.notDerivable()
+            }
+        }
+    }
+
+    loadInputRecipeRef(input, prefill) {
+        const {stream, loadSourceRecipe$} = this.props
+        stream('LOAD_MOSAIC',
+            loadSourceRecipe$(input.id).pipe(takeUntil(this.cancel$)),
+            mosaic => {
+                const dataSets = selectFrom(mosaic, 'model.sources.dataSets')
+                this.setClassificationBands(dataSets ? getDataSetBands(mosaic) : undefined)
+                if (!prefill) {
+                    return
+                }
+                if (mosaic.model.sceneSelectionOptions && mosaic.model.sceneSelectionOptions.type === 'SELECT') {
+                    this.setClassificationError('process.pyeoAlerts.classification.selectedScenesUnsupported', {clearLegend: true})
+                    return
+                }
+                const options = mosaic.model.compositeOptions || mosaic.model.options
+                const [start, end] = getRecipeType(mosaic.type).getDateRange(mosaic)
+                this.prefill({options, sources: mosaic.model.sources, start, end})
+            },
+            error => Notifications.error({message: msg('process.pyeoAlerts.classification.mosaicLoadError'), error})
+        )
+    }
+
+    loadInputAsset(input, prefill) {
+        const {stream} = this.props
+        stream('LOAD_ASSET_METADATA',
+            api.gee.assetMetadata$({asset: input.id}).pipe(takeUntil(this.cancel$)),
+            metadata => {
+                this.setClassificationBands((metadata && metadata.bandNames) || undefined)
+                if (!prefill) {
+                    return
+                }
+                const props = (metadata && metadata.properties) || {}
+                const optionsString = props.recipe_compositeOptions || props.recipe_options
+                const sourcesString = props.recipe_sources
+                const start = props['system:time_start']
+                const end = props['system:time_end']
+                if (!optionsString || !sourcesString || start === undefined || end === undefined) {
+                    this.notDerivable()
+                    return
+                }
+                this.prefill({options: JSON.parse(optionsString), sources: JSON.parse(sourcesString), start, end})
+            },
+            error => Notifications.error({message: msg('process.pyeoAlerts.classification.assetLoadError'), error})
+        )
+    }
+
+    prefill({options, sources, start, end}) {
+        const {inputs} = this.props
+        // Optical datasets: follow the classification's native default only while the user
+        // hasn't manually chosen datasets — otherwise keep their selection.
+        if (!this.dataSetsTouched) {
+            inputs.dataSets.set(_.uniq(Object.values((sources && sources.dataSets) || {}).flat()))
+        }
+        inputs.cloudPercentageThreshold.set(
+            sources && sources.cloudPercentageThreshold !== undefined ? sources.cloudPercentageThreshold : 75
+        )
+        // Pre-process + Dates live in other panels: stage them and commit on Apply (onApply),
+        // so merely selecting a classification never mutates the recipe or the map.
+        const baselineStart = toDateString(start)
+        const baselineEnd = toDateString(end)
+        // Default the monitoring window to (at most) one year after the baseline's last date.
+        const monitoringEnd = moment
+            .min(moment(baselineEnd, DATE_FORMAT).add(1, 'year'), moment())
+            .format(DATE_FORMAT)
+        this.pendingModel = {
+            options,
+            dates: {
+                baselineStart,
+                baselineEnd,
+                monitoringStart: baselineEnd, // end-exclusive ⇒ seamless
+                monitoringEnd,
+                derived: true
+            }
+        }
+    }
+
+    notDerivable() {
+        this.setClassificationError('process.pyeoAlerts.classification.notDerivable')
+        this.pendingModel = {dates: {derived: false}}
+    }
+
+    onApply() {
+        // Commit the classification-derived Pre-process/Dates params staged on select.
+        const {recipeActionBuilder} = this.props
+        if (!this.pendingModel) {
+            return
+        }
+        const {options, dates} = this.pendingModel
+        const actionBuilder = recipeActionBuilder('COMMIT_CLASSIFICATION_DERIVED', {})
+        if (options) {
+            actionBuilder.assign('model.options', options)
+        }
+        if (dates) {
+            Object.entries(dates).forEach(([key, value]) => actionBuilder.set(`model.dates.${key}`, value))
+        }
+        actionBuilder.dispatch()
+        this.pendingModel = null
+    }
+
+    onCancel() {
+        // Drop staged params. If a different classification was previewed, restore the
+        // committed one's legend; otherwise the current legend already matches.
+        this.pendingModel = null
+        const {model} = this.props
+        if (this.loadedClassificationId !== (model && model.classification)) {
+            this.syncLegendFromModel()
+        }
+    }
+
+    setClassificationError(key, {clearLegend = false} = {}) {
+        this.setState({classificationError: msg(key)})
+        if (clearLegend) {
+            this.setLegend(undefined)
+        }
+    }
+
+    setLegend(legend) {
+        const {recipeActionBuilder} = this.props
+        recipeActionBuilder('SET_CLASSIFICATION_LEGEND', {})
+            .set('ui.classificationLegend', legend)
+            .dispatch()
+    }
+
+    // The classification's input-imagery band names — read by the Options panel to enable/disable
+    // the index gate (an RGB baseline can't produce NDVI/NDMI/NBR).
+    setClassificationBands(classificationBands) {
+        const {recipeActionBuilder} = this.props
+        recipeActionBuilder('SET_CLASSIFICATION_BANDS', {})
+            .set('ui.classificationBands', classificationBands)
+            .dispatch()
+    }
+}
+
+const valuesToModel = ({classification, dataSets, cloudPercentageThreshold, changeFromClasses, changeToClasses}) => ({
+    classification,
+    dataSets: toSources(_.isArray(dataSets) ? dataSets : [dataSets]),
+    cloudPercentageThreshold,
+    changeFromClasses,
+    changeToClasses
+})
+
+const modelToValues = ({classification, dataSets, cloudPercentageThreshold, changeFromClasses, changeToClasses}) => ({
+    classification,
+    dataSets: _.uniq(Object.values(dataSets || {}).flat()),
+    cloudPercentageThreshold: cloudPercentageThreshold !== undefined ? cloudPercentageThreshold : 75,
+    changeFromClasses: changeFromClasses || [],
+    changeToClasses: changeToClasses || []
+})
+
+export const Sources = compose(
+    _Sources,
+    connect(mapStateToProps),
+    withRecipe(mapRecipeToProps),
+    recipeFormPanel({id: 'sources', fields, modelToValues, valuesToModel}),
+    recipeAccess()
+)

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/sources/sources.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/panels/sources/sources.module.css
@@ -1,0 +1,19 @@
+.panel {
+    width: 30rem;
+}
+
+/* Fixed height so the From/To area occupies the same space in every state
+   (placeholder, spinner, chips) — no layout jump. Scrolls if a legend has many classes. */
+.changeClasses {
+    height: 11rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.changeClassesMessage {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlerts.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlerts.jsx
@@ -1,0 +1,75 @@
+import moment from 'moment'
+import React from 'react'
+
+import {initializeLayers} from '~/app/home/body/process/recipe/recipeImageLayerSource'
+import {recipe} from '~/app/home/body/process/recipeContext'
+import {Map} from '~/app/home/map/map'
+import {compose} from '~/compose'
+import {selectFrom} from '~/stateUtils'
+import {msg} from '~/translate'
+
+import {Aoi} from '../aoi'
+import {getAvailableBands} from './bands'
+import {PyeoAlertsToolbar} from './panels/pyeoAlertsToolbar'
+import {defaultModel} from './pyeoAlertsRecipe'
+import {getPreSetVisualizations} from './visualizations'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+const mapRecipeToProps = recipe => ({
+    aoi: selectFrom(recipe, 'model.aoi'),
+    savedLayers: selectFrom(recipe, 'layers')
+})
+
+class _PyeoAlerts extends React.Component {
+    constructor(props) {
+        super(props)
+        const {savedLayers, recipeId} = props
+        initializeLayers({recipeId, savedLayers})
+    }
+
+    render() {
+        const {aoi} = this.props
+        return (
+            <Map>
+                <PyeoAlertsToolbar/>
+                <Aoi value={aoi}/>
+            </Map>
+        )
+    }
+}
+
+const PyeoAlerts = compose(
+    _PyeoAlerts,
+    recipe({defaultModel, mapRecipeToProps})
+)
+
+const getDateRange = recipe => {
+    const {monitoringStart, monitoringEnd} = selectFrom(recipe, 'model.dates') || {}
+    return [
+        moment.utc(monitoringStart || moment().startOf('year').format(DATE_FORMAT), DATE_FORMAT),
+        moment.utc(monitoringEnd || moment().format(DATE_FORMAT), DATE_FORMAT)
+    ]
+}
+
+const getDependentRecipeIds = recipe => {
+    const classificationId = selectFrom(recipe, 'model.sources.classification')
+    return classificationId ? [classificationId] : []
+}
+
+export default () => ({
+    id: 'PYEO_ALERTS',
+    labels: {
+        name: msg('process.pyeoAlerts.create'),
+        creationDescription: msg('process.pyeoAlerts.description'),
+        tabPlaceholder: msg('process.pyeoAlerts.tabPlaceholder')
+    },
+    tags: ['CHANGE', 'ALERTS'],
+    components: {
+        recipe: PyeoAlerts
+    },
+    getDependentRecipeIds,
+    getDateRange,
+    getAvailableBands,
+    getPreSetVisualizations
+})

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlertsImageLayer.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlertsImageLayer.jsx
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {VisualizationSelector} from '~/app/home/map/imageLayerSource/visualizationSelector'
+import {MapAreaLayout} from '~/app/home/map/mapAreaLayout'
+import {asFunctionalComponent} from '~/classComponent'
+import {compose} from '~/compose'
+import {msg} from '~/translate'
+
+import {getAvailableBands} from './bands'
+import {getPreSetVisualizations} from './visualizations'
+
+const defaultLayerConfig = {
+    panSharpen: false
+}
+
+class _PyeoAlertsImageLayer extends React.Component {
+    render() {
+        const {layer, map} = this.props
+        return (
+            <MapAreaLayout
+                layer={layer}
+                form={this.renderImageLayerForm()}
+                map={map}
+            />
+        )
+    }
+
+    renderImageLayerForm() {
+        const {recipe, source, layerConfig = {}} = this.props
+        const availableBands = getAvailableBands(recipe)
+        const preSetOptions = getPreSetVisualizations(recipe)
+            .filter(({bands}) => availableBands[bands[0]])
+            .map(visParams => {
+                const band = visParams.bands[0]
+                return {...availableBands[band], value: band, visParams}
+            })
+        const options = [{
+            label: msg('process.pyeoAlerts.layers.imageLayer.preSets'),
+            options: preSetOptions
+        }]
+        return (
+            <VisualizationSelector
+                source={source}
+                recipe={recipe}
+                presetOptions={options}
+                selectedVisParams={layerConfig.visParams}
+            />
+        )
+    }
+}
+
+export const PyeoAlertsImageLayer = compose(
+    _PyeoAlertsImageLayer,
+    asFunctionalComponent({
+        layerConfig: defaultLayerConfig
+    })
+)
+
+PyeoAlertsImageLayer.propTypes = {
+    recipe: PropTypes.object.isRequired,
+    source: PropTypes.object.isRequired,
+    layer: PropTypes.object,
+    layerConfig: PropTypes.object,
+    map: PropTypes.object
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlertsRecipe.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/pyeoAlertsRecipe.js
@@ -1,0 +1,82 @@
+import moment from 'moment'
+
+import {recipeActionBuilder} from '~/app/home/body/process/recipe'
+import {pyramidingPolicies, submitRetrieveRecipeTask as submitTask} from '~/app/home/body/process/recipe/recipeTaskSubmitter'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+export const defaultModel = {
+    aoi: {},
+    sources: {
+        classification: undefined,
+        dataSets: {},
+        cloudPercentageThreshold: 75,
+        changeFromClasses: [],
+        changeToClasses: []
+    },
+    // Pre-process ("PRC") — pre-filled from the classification mosaic's compositeOptions.
+    // Defaults mirror optical mosaic (opticalMosaicRecipe.js:32-51).
+    options: {
+        corrections: ['SR', 'BRDF'],
+        brdfMultiplier: 4,
+        filters: [],
+        orbitOverlap: 'KEEP',
+        tileOverlap: 'QUICK_REMOVE',
+        includedCloudMasking: ['sepalCloudScore', 'landsatCFMask', 'sentinel2CloudScorePlus'],
+        sentinel2CloudProbabilityMaxCloudProbability: 65,
+        sentinel2CloudScorePlusBand: 'cs_cdf',
+        sentinel2CloudScorePlusMaxCloudProbability: 45,
+        landsatCFMaskCloudMasking: 'MODERATE',
+        landsatCFMaskCloudShadowMasking: 'MODERATE',
+        landsatCFMaskCirrusMasking: 'MODERATE',
+        landsatCFMaskDilatedCloud: 'REMOVE',
+        sepalCloudScoreMaxCloudProbability: 30,
+        cloudBuffer: 0,
+        holes: 'ALLOW',
+        snowMasking: 'ON',
+        compose: 'MEDOID'
+    },
+    dates: {
+        baselineStart: moment().subtract(2, 'years').startOf('year').format(DATE_FORMAT),
+        baselineEnd: moment().subtract(1, 'years').startOf('year').format(DATE_FORMAT),
+        monitoringStart: moment().subtract(1, 'years').startOf('year').format(DATE_FORMAT),
+        monitoringEnd: moment().format(DATE_FORMAT),
+        derived: false
+    },
+    // Change-detection params (renamed from model.options).
+    pyeoAlertsOptions: {
+        minConsecutiveDetections: 2,
+        indexGate: {index: 'ndvi', threshold: 0.2}
+    }
+}
+
+export const RecipeActions = id => {
+    const actionBuilder = recipeActionBuilder(id)
+
+    return {
+        setBands(bands) {
+            return actionBuilder('SET_BANDS', {bands})
+                .set('ui.bands.selection', bands)
+                .dispatch()
+        },
+        setClassificationLegend(classificationLegend) {
+            return actionBuilder('SET_CLASSIFICATION_LEGEND', {classificationLegend})
+                .set('ui.classificationLegend', classificationLegend)
+                .dispatch()
+        },
+        retrieve(retrieveOptions) {
+            return actionBuilder('REQUEST_PYEO_ALERTS_RETRIEVAL', {retrieveOptions})
+                .setAll({
+                    'ui.retrieveState': 'SUBMITTED',
+                    'ui.retrieveOptions': retrieveOptions
+                })
+                .sideEffect(recipe => submitRetrieveRecipeTask(recipe))
+                .dispatch()
+        }
+    }
+}
+
+const submitRetrieveRecipeTask = recipe =>
+    submitTask(recipe, {
+        pyramidingPolicy: pyramidingPolicies.sample
+    })

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/toDateString.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/toDateString.js
@@ -1,0 +1,18 @@
+// Normalize a date to a 'YYYY-MM-DD' string. Accepts a Moment-like value
+// (getRecipeType(...).getDateRange returns Moments), an epoch-ms number
+// (asset metadata system:time_start/end), or a date/ISO string.
+export default value => {
+    if (value === null || value === undefined) {
+        return value
+    }
+    if (typeof value === 'string') {
+        return value.slice(0, 10)
+    }
+    if (typeof value === 'number') {
+        return new Date(value).toISOString().slice(0, 10)
+    }
+    if (typeof value.format === 'function') {
+        return value.format('YYYY-MM-DD')
+    }
+    return value
+}

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/toDateString.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/toDateString.test.js
@@ -1,0 +1,19 @@
+import toDateString from './toDateString'
+
+it('formats epoch milliseconds (UTC) to YYYY-MM-DD', () => {
+    expect(toDateString(1609459200000)).toEqual('2021-01-01')
+})
+it('passes a YYYY-MM-DD string through', () => {
+    expect(toDateString('2020-12-31')).toEqual('2020-12-31')
+})
+it('truncates an ISO string to the date', () => {
+    expect(toDateString('2020-12-31T10:11:12.000Z')).toEqual('2020-12-31')
+})
+it('formats a Moment-like value via .format', () => {
+    const moment = {format: fmt => (fmt === 'YYYY-MM-DD' ? '2020-06-30' : '')}
+    expect(toDateString(moment)).toEqual('2020-06-30')
+})
+it('returns null/undefined unchanged', () => {
+    expect(toDateString(null)).toEqual(null)
+    expect(toDateString(undefined)).toEqual(undefined)
+})

--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/visualizations.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/visualizations.js
@@ -1,0 +1,45 @@
+import moment from 'moment'
+
+import {normalize} from '~/app/home/map/visParams/visParams'
+import {selectFrom} from '~/stateUtils'
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+const DATE_PALETTE = ['#000000', '#781C81', '#3F60AE', '#539EB6', '#6DB388', '#CAB843', '#E78532', '#D92120']
+
+const toFractionalYear = (date, fallback) => {
+    const m = moment(date, DATE_FORMAT, true)
+    return m.isValid() ? m.year() + (m.dayOfYear() - 1) / (m.isLeapYear() ? 366 : 365) : fallback
+}
+
+export const getPreSetVisualizations = recipe => {
+    const monitoringStart = selectFrom(recipe, 'model.dates.monitoringStart')
+    const monitoringEnd = selectFrom(recipe, 'model.dates.monitoringEnd')
+    return [
+        // total_changes is the per-pixel count of change detections across the monitoring
+        // scenes; its true ceiling is ~the scene count, so this max is a sensible default
+        // the user can raise in the visualization editor.
+        normalize({
+            type: 'continuous',
+            bands: ['total_changes'],
+            min: 0,
+            max: 10,
+            palette: ['#ffffbf', '#d7191c']
+        }),
+        normalize({
+            type: 'continuous',
+            bands: ['post_fcd_change_repeatability_pct'],
+            min: 0,
+            max: 100,
+            palette: ['#ffffd4', '#fed98e', '#fe9929', '#d95f0e', '#993404']
+        }),
+        normalize({
+            type: 'continuous',
+            bands: ['fcd_decision_map'],
+            dataType: 'fractionalYears',
+            min: toFractionalYear(monitoringStart, 2000),
+            max: toFractionalYear(monitoringEnd, 2100),
+            palette: DATE_PALETTE
+        })
+    ]
+}

--- a/modules/gui/src/app/home/body/process/recipeImageLayers.js
+++ b/modules/gui/src/app/home/body/process/recipeImageLayers.js
@@ -12,6 +12,7 @@ import {MaskingImageLayer} from './recipe/masking/maskingImageLayer'
 import {OpticalMosaicImageLayer} from './recipe/opticalMosaic/opticalMosaicImageLayer'
 import {PhenologyImageLayer} from './recipe/phenology/phenologyImageLayer'
 import {PlanetMosaicImageLayer} from './recipe/planetMosaic/planetMosaicImageLayer'
+import {PyeoAlertsImageLayer} from './recipe/pyeoAlerts/pyeoAlertsImageLayer'
 import {RadarMosaicImageLayer} from './recipe/radarMosaic/radarMosaicImageLayer'
 import {RegressionImageLayer} from './recipe/regression/regressionImageLayer'
 import {RemappingImageLayer} from './recipe/remapping/remappingImageLayer'
@@ -33,6 +34,7 @@ export const registerRecipeImageLayers = () => {
     addRecipeImageLayer('INDEX_CHANGE', IndexChangeImageLayer)
     addRecipeImageLayer('REMAPPING', RemappingImageLayer)
     addRecipeImageLayer('CHANGE_ALERTS', ChangeAlertsImageLayer)
+    addRecipeImageLayer('PYEO_ALERTS', PyeoAlertsImageLayer)
     addRecipeImageLayer('CCDC', CCDCImageLayer)
     addRecipeImageLayer('CCDC_SLICE', CCDCSliceImageLayer)
     addRecipeImageLayer('TIME_SERIES', TimeSeriesImageLayer)

--- a/modules/gui/src/app/home/body/process/recipeTypes.js
+++ b/modules/gui/src/app/home/body/process/recipeTypes.js
@@ -12,6 +12,7 @@ import masking from './recipe/masking/masking'
 import opticalMosaic from './recipe/opticalMosaic/opticalMosaic'
 import phenology from './recipe/phenology/phenology'
 import planetMosaic from './recipe/planetMosaic/planetMosaic'
+import pyeoAlerts from './recipe/pyeoAlerts/pyeoAlerts'
 import radarMosaic from './recipe/radarMosaic/radarMosaic'
 import regression from './recipe/regression/regression'
 import remapping from './recipe/remapping/remapping'
@@ -37,6 +38,7 @@ export const registerRecipeTypes = () => {
     addRecipeType(indexChange())
     addRecipeType(remapping())
     addRecipeType(changeAlerts())
+    addRecipeType(pyeoAlerts())
     addRecipeType(baytsHistorical())
     addRecipeType(baytsAlerts())
     addRecipeType(phenology())

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -1454,6 +1454,133 @@
       },
       "tabPlaceholder": "CCDC_slice"
     },
+    "pyeoAlerts": {
+      "create": "Forest Change Alerts (PyEO)",
+      "description": "Detect forest land-cover change by classifying a monitoring period against a baseline composite, with optional index confirmation and temporal-consistency filtering.",
+      "tabPlaceholder": "Forest_alerts",
+      "layers": {
+        "imageLayer": {
+          "preSets": "Presets"
+        }
+      },
+      "error": {
+        "noImages": "No monitoring images match the recipe configuration. Update the dates or sources.",
+        "noChangeClasses": "Select at least one \"From\" class and one \"To\" class in the change-detection options."
+      },
+      "panel": {
+        "dates": {
+          "title": "Date ranges",
+          "button": "DAT",
+          "tooltip": "Pick the baseline window (used to build the reference composite) and the monitoring window (whose individual acquisitions are compared to the baseline).",
+          "form": {
+            "baseline": {
+              "label": "Baseline window"
+            },
+            "monitoring": {
+              "label": "Monitoring window"
+            },
+            "baselineStart": {
+              "label": "From",
+              "required": "Required",
+              "malformed": "Use YYYY-MM-DD",
+              "beforeEnd": "Baseline start must be before baseline end"
+            },
+            "baselineEnd": {
+              "label": "To",
+              "required": "Required",
+              "malformed": "Use YYYY-MM-DD",
+              "beforeMonitoring": "Baseline must end before monitoring starts"
+            },
+            "monitoringStart": {
+              "label": "From",
+              "required": "Required",
+              "malformed": "Use YYYY-MM-DD",
+              "beforeEnd": "Monitoring start must be before monitoring end"
+            },
+            "monitoringEnd": {
+              "label": "To",
+              "required": "Required",
+              "malformed": "Use YYYY-MM-DD"
+            }
+          }
+        },
+        "sources": {
+          "title": "Sources",
+          "button": "SRC",
+          "tooltip": "Pick the classification recipe and optical datasets, and choose which From→To class transitions count as change.",
+          "form": {
+            "dataSets": {
+              "label": "Optical datasets",
+              "tooltip": "One or more Sentinel-2 / Landsat collections. Bands are harmonised across the selection.",
+              "required": "Pick at least one optical dataset"
+            },
+            "cloudPercentageThreshold": {
+              "label": "Maximum scene cloud cover",
+              "tooltip": "Drop scenes whose CLOUDY_PIXEL_PERCENTAGE exceeds this value before classification.",
+              "value": "{value}%"
+            },
+            "classification": {
+              "label": "Classification recipe",
+              "tooltip": "Only Classification recipes appear here. Class IDs and labels are pulled from the selected recipe.",
+              "placeholder": "Select a Classification recipe",
+              "required": "Pick a Classification recipe"
+            },
+            "changeFromClasses": {
+              "label": "FROM classes (baseline)",
+              "tooltip": "Classes in the baseline class map that count as the 'from' side of a change. Typically forest classes.",
+              "required": "Pick at least one FROM class"
+            },
+            "changeToClasses": {
+              "label": "TO classes (monitoring)",
+              "tooltip": "Classes in any monitoring class map that count as the 'to' side of a change. A class chosen as FROM can't also be TO.",
+              "required": "Pick at least one TO class",
+              "overlap": "FROM and TO classes must not overlap"
+            },
+            "changeClasses": {
+              "noClassification": "Select a classification recipe to choose From/To classes"
+            }
+          }
+        },
+        "options": {
+          "title": "Change rules",
+          "button": "OPT",
+          "tooltip": "Optional spectral-index confirmation and the temporal-consistency threshold.",
+          "form": {
+            "useIndexGate": {
+              "label": "Require index drop",
+              "tooltip": "Require the chosen index to drop by at least the threshold (baseline − monitoring) before an alert is confirmed. Only decreases count — an index increase never confirms a change.",
+              "off": "No",
+              "on": "Yes",
+              "unavailable": "The selected classification's baseline imagery has no near-infrared band, so it cannot produce a spectral index; the index gate is unavailable."
+            },
+            "gateIndex": {
+              "label": "Index",
+              "tooltip": "Spectral index whose drop (baseline − monitoring) confirms an alert — a drop signals disturbance. Options depend on the selected sources.",
+              "required": "Pick an index"
+            },
+            "gateThreshold": {
+              "label": "Minimum drop",
+              "tooltip": "Minimum drop in the index (baseline − monitoring) needed to confirm an alert. Only decreases count — an index increase never confirms a change.",
+              "required": "Set a threshold",
+              "value": "{value}"
+            },
+            "minConsecutiveDetections": {
+              "label": "Minimum consecutive detections",
+              "tooltip": "A pixel only flags as an alert after this many consecutive monitoring acquisitions show the same change.",
+              "value": "{value} images"
+            }
+          }
+        }
+      },
+      "classification": {
+        "loadError": "Failed to load the classification recipe: {error}",
+        "mosaicLoadError": "Failed to load the classification's imagery: {error}",
+        "assetLoadError": "Failed to read the classification asset metadata: {error}",
+        "singleInputRequired": "This classification uses more than one input image, which isn't supported here. Choose a classification with a single input.",
+        "selectedScenesUnsupported": "This classification was trained on hand-selected scenes, which isn't supported yet. Choose a classification trained on a date range.",
+        "notDerivable": "Couldn't read the imagery dates from this classification (external asset). Set the baseline and monitoring dates manually."
+      }
+    },
     "changeAlerts": {
       "create": "Change Alerts",
       "description": "Generate change alerts using a CCDC as baseline.",


### PR DESCRIPTION
Adds a **PYEO_ALERTS** recipe integrating University of Leicester's PyEO forest change-detection algorithm: it runs UoL's change algorithm over a monitoring window against a baseline Classification recipe.

- **EE** `lib/js/ee/src/pyeo/` — `runPyeoChangeAlerts.js` (UoL algorithm, adapted to SEPAL module conventions), `pyeoAlerts.js` wrapper, `params.js`; monitoring collection reuses `getCollection$`.
- **GUI** `recipe/pyeoAlerts/` — sources/dates/options/retrieve panels, layers, strings.

`runPyeoChangeAlerts.js` derives from UoL's code (GPL-3.0, clcr/pyeo) under the FAO/UoL LoA.