### PR TITLE
Added support for an external logo URL in the apps catalog.

### DIFF
--- a/modules/gui/src/app/home/body/apps/appList/appItem.jsx
+++ b/modules/gui/src/app/home/body/apps/appList/appItem.jsx
@@ -1,31 +1,37 @@
 import PropTypes from 'prop-types'
+import {useState} from 'react'
 
+import {fallbackLogoUrl, logoUrl} from '~/appsCatalog'
 import {CrudItem} from '~/widget/crudItem'
 
 import styles from './appItem.module.css'
 
-const imageUrl = logoRef => logoRef
-    ? `/api/apps/images/${logoRef}`
-    : null
+export const AppItem = ({app, className, highlight, highlightClassName}) => {
+    const [src, setSrc] = useState(logoUrl(app))
 
-const renderLogo = logoRef =>
-    logoRef
+    const onError = () =>
+        setSrc(current => current === logoUrl(app) ? fallbackLogoUrl(app) : null)
+
+    const logo = src
         ? <img
             className={styles.logo}
-            src={imageUrl(logoRef)}
+            src={src}
             alt=''
+            onError={onError}
         />
         : null
 
-export const AppItem = ({app: {label, tagline, logoRef}, className, highlight, highlightClassName}) =>
-    <CrudItem
-        className={className}
-        title={label}
-        description={tagline || '...'}
-        image={renderLogo(logoRef)}
-        highlight={highlight}
-        highlightClassName={highlightClassName}
-    />
+    return (
+        <CrudItem
+            className={className}
+            title={app.label}
+            description={app.tagline || '...'}
+            image={logo}
+            highlight={highlight}
+            highlightClassName={highlightClassName}
+        />
+    )
+}
 
 AppItem.propTypes = {
     app: PropTypes.object,

--- a/modules/gui/src/appsCatalog.js
+++ b/modules/gui/src/appsCatalog.js
@@ -28,7 +28,7 @@ const mergeTags = (parentTags, childTags) => {
 // A child declaring either logo key owns both of them, so a parent `logo` can
 // never win over a logo the child chose to express as a `logoRef`.
 const logoOwner = (parent, child) =>
-    child.logo || child.logoRef ? child : parent
+    child.logo !== undefined || child.logoRef !== undefined ? child : parent
 
 const flattenChild = (parent, child) => {
     const route = child.route !== undefined ? child.route : child.id
@@ -76,14 +76,14 @@ export const normalizeAppsCatalog = appsSpec => {
     return {...appsSpec, apps: out}
 }
 
-const isAbsoluteUrl = value => /^https?:\/\//i.test(value)
+const isAbsoluteHttpsUrl = value => /^https:\/\//i.test(value)
 
 const imageUrl = logoRef => logoRef ? `/api/apps/images/${logoRef}` : null
 
 // `logo` points at an externally hosted image; `logoRef` names one installed on
 // the SEPAL server and stays the fallback for catalogs that predate `logo`.
 export const logoUrl = ({logo, logoRef} = {}) =>
-    logo && isAbsoluteUrl(logo)
+    logo && isAbsoluteHttpsUrl(logo)
         ? logo
         : imageUrl(logoRef)
 

--- a/modules/gui/src/appsCatalog.js
+++ b/modules/gui/src/appsCatalog.js
@@ -25,9 +25,15 @@ const mergeTags = (parentTags, childTags) => {
     return out
 }
 
+// A child declaring either logo key owns both of them, so a parent `logo` can
+// never win over a logo the child chose to express as a `logoRef`.
+const logoOwner = (parent, child) =>
+    child.logo || child.logoRef ? child : parent
+
 const flattenChild = (parent, child) => {
     const route = child.route !== undefined ? child.route : child.id
     const path = child.path || joinPath(parent.path, route)
+    const logo = logoOwner(parent, child)
     // Spread the child first so any non-whitelisted fields (e.g. `single`,
     // `alt`, future additions) carry through, then override with derived and
     // inherited values.
@@ -42,7 +48,8 @@ const flattenChild = (parent, child) => {
         pinned: pick(child.pinned, false),
         googleAccountRequired: pick(child.googleAccountRequired, parent.googleAccountRequired, false),
         disabled: pick(child.disabled, parent.disabled),
-        logoRef: pick(child.logoRef, parent.logoRef, 'sepal.png'),
+        logo: logo.logo,
+        logoRef: pick(logo.logoRef, 'sepal.png'),
         author: pick(child.author, parent.author),
         projectLink: pick(child.projectLink, parent.projectLink),
         description: pick(child.description, ''),
@@ -67,4 +74,21 @@ export const normalizeAppsCatalog = appsSpec => {
         }
     }
     return {...appsSpec, apps: out}
+}
+
+const isAbsoluteUrl = value => /^https?:\/\//i.test(value)
+
+const imageUrl = logoRef => logoRef ? `/api/apps/images/${logoRef}` : null
+
+// `logo` points at an externally hosted image; `logoRef` names one installed on
+// the SEPAL server and stays the fallback for catalogs that predate `logo`.
+export const logoUrl = ({logo, logoRef} = {}) =>
+    logo && isAbsoluteUrl(logo)
+        ? logo
+        : imageUrl(logoRef)
+
+// Source to swap in when the browser fails to load the logoUrl choice.
+export const fallbackLogoUrl = app => {
+    const fallback = imageUrl(app?.logoRef)
+    return logoUrl(app) === fallback ? null : fallback
 }

--- a/modules/gui/src/appsCatalog.test.js
+++ b/modules/gui/src/appsCatalog.test.js
@@ -1,4 +1,4 @@
-import {normalizeAppsCatalog} from './appsCatalog'
+import {fallbackLogoUrl, logoUrl, normalizeAppsCatalog} from './appsCatalog'
 
 describe('normalizeAppsCatalog', () => {
     it('passes single-container apps through unchanged', () => {
@@ -109,5 +109,73 @@ describe('normalizeAppsCatalog', () => {
             apps: [{id: 'a', route: 'a', label: 'A', googleAccountRequired: false}]
         }]}
         expect(normalizeAppsCatalog(input).apps[1].googleAccountRequired).toBe(false)
+    })
+
+    it('inherits the parent logo when a bundle child declares no logo of its own', () => {
+        const input = {apps: [{
+            id: 'p', path: '/api/p', endpoint: 'docker', logo: 'https://example.org/p.png',
+            apps: [{id: 'a', route: 'a', label: 'A'}]
+        }]}
+        expect(normalizeAppsCatalog(input).apps[1].logo).toBe('https://example.org/p.png')
+    })
+
+    it('lets a bundle child logoRef replace an inherited parent logo', () => {
+        const input = {apps: [{
+            id: 'p', path: '/api/p', endpoint: 'docker', logo: 'https://example.org/p.png',
+            apps: [{id: 'a', route: 'a', label: 'A', logoRef: 'child.png'}]
+        }]}
+        const child = normalizeAppsCatalog(input).apps[1]
+        expect(child.logo).toBeUndefined()
+        expect(child.logoRef).toBe('child.png')
+    })
+
+    it('lets a bundle child logo replace an inherited parent logoRef', () => {
+        const input = {apps: [{
+            id: 'p', path: '/api/p', endpoint: 'docker', logoRef: 'parent.png',
+            apps: [{id: 'a', route: 'a', label: 'A', logo: 'https://example.org/a.png'}]
+        }]}
+        const child = normalizeAppsCatalog(input).apps[1]
+        expect(child.logo).toBe('https://example.org/a.png')
+        expect(child.logoRef).toBe('sepal.png')
+    })
+})
+
+describe('logoUrl', () => {
+    it('uses an absolute logo URL as-is', () => {
+        expect(logoUrl({logo: 'https://example.org/logos/foo.png'})).toBe('https://example.org/logos/foo.png')
+    })
+
+    it('prefers logo over logoRef', () => {
+        expect(logoUrl({logo: 'http://example.org/foo.png', logoRef: 'sepal.png'})).toBe('http://example.org/foo.png')
+    })
+
+    it('ignores a relative logo and falls back to logoRef', () => {
+        expect(logoUrl({logo: 'logos/foo.png', logoRef: 'sepal.png'})).toBe('/api/apps/images/sepal.png')
+    })
+
+    it('ignores a logo with a non-http scheme', () => {
+        expect(logoUrl({logo: 'javascript:alert(1)', logoRef: 'sepal.png'})).toBe('/api/apps/images/sepal.png')
+    })
+
+    it('serves logoRef from app-manager when no logo is set', () => {
+        expect(logoUrl({logoRef: 'rstudio-ball.svg'})).toBe('/api/apps/images/rstudio-ball.svg')
+    })
+
+    it('returns null when neither logo nor logoRef is set', () => {
+        expect(logoUrl({})).toBeNull()
+    })
+})
+
+describe('fallbackLogoUrl', () => {
+    it('falls back to the logoRef image when a remote logo fails to load', () => {
+        expect(fallbackLogoUrl({logo: 'https://example.org/foo.png', logoRef: 'sepal.png'})).toBe('/api/apps/images/sepal.png')
+    })
+
+    it('returns null when the failed logo has no logoRef to fall back to', () => {
+        expect(fallbackLogoUrl({logo: 'https://example.org/foo.png'})).toBeNull()
+    })
+
+    it('returns null when the logoRef image itself failed', () => {
+        expect(fallbackLogoUrl({logoRef: 'sepal.png'})).toBeNull()
     })
 })

--- a/modules/gui/src/appsCatalog.test.js
+++ b/modules/gui/src/appsCatalog.test.js
@@ -138,15 +138,25 @@ describe('normalizeAppsCatalog', () => {
         expect(child.logo).toBe('https://example.org/a.png')
         expect(child.logoRef).toBe('sepal.png')
     })
+
+    it('preserves an explicitly empty child logoRef instead of inheriting the parent logo', () => {
+        const input = {apps: [{
+            id: 'p', path: '/api/p', endpoint: 'docker', logo: 'https://example.org/p.png',
+            apps: [{id: 'a', route: 'a', label: 'A', logoRef: ''}]
+        }]}
+        const child = normalizeAppsCatalog(input).apps[1]
+        expect(child.logo).toBeUndefined()
+        expect(child.logoRef).toBe('')
+    })
 })
 
 describe('logoUrl', () => {
-    it('uses an absolute logo URL as-is', () => {
-        expect(logoUrl({logo: 'https://example.org/logos/foo.png'})).toBe('https://example.org/logos/foo.png')
+    it('prefers an HTTPS logo over logoRef', () => {
+        expect(logoUrl({logo: 'https://example.org/logos/foo.png', logoRef: 'sepal.png'})).toBe('https://example.org/logos/foo.png')
     })
 
-    it('prefers logo over logoRef', () => {
-        expect(logoUrl({logo: 'http://example.org/foo.png', logoRef: 'sepal.png'})).toBe('http://example.org/foo.png')
+    it('ignores an HTTP logo and falls back to logoRef', () => {
+        expect(logoUrl({logo: 'http://example.org/foo.png', logoRef: 'sepal.png'})).toBe('/api/apps/images/sepal.png')
     })
 
     it('ignores a relative logo and falls back to logoRef', () => {


### PR DESCRIPTION
Apps in the catalog can now carry a `logo` key holding an absolute https URL, which the GUI uses instead of an image installed on the SEPAL server. Anything that is not an absolute http(s) URL — including a missing key — falls back to the current `logoRef` → `/api/apps/images/<file>` behaviour, so existing catalogs render exactly as before. If a remote logo fails to load, the image swaps to the `logoRef` image, and if that fails too it is dropped rather than showing a broken-image icon.

Bundle children inherit `logo` and `logoRef` as a pair, so a parent `logo` cannot override a logo the child chose to express as a `logoRef`. The resolution itself lives in `appsCatalog.js` (`logoUrl` / `fallbackLogoUrl`) and is covered by 12 new unit tests; `appItem.jsx` only binds it and holds the error-fallback state. Nothing changes server-side — app-manager serves the catalog payload verbatim.

The first catalog entry using the new key is dfguerrerom/sepal-apps-catalog#73 (se.plan).