### PR TITLE
Replaced the removed Google DrawingManager with Terra Draw

### DIFF
--- a/modules/gui/package-lock.json
+++ b/modules/gui/package-lock.json
@@ -64,6 +64,8 @@
                 "remark-gfm": "^4.0.1",
                 "rxjs": "7.8.2",
                 "sepal": "../../lib/js/shared",
+                "terra-draw": "^1.32.3",
+                "terra-draw-google-maps-adapter": "^1.6.1",
                 "thememirror": "^2.0.1"
             },
             "devDependencies": {
@@ -8715,6 +8717,22 @@
             "license": "MIT",
             "dependencies": {
                 "tinyqueue": "^2.0.0"
+            }
+        },
+        "node_modules/terra-draw": {
+            "version": "1.32.3",
+            "resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.32.3.tgz",
+            "integrity": "sha512-pQpwL8winsDW6/DbBgsaZKeMc83D+HqokxR+t1AbrN4U7C4mGgEfCtmRix1/5L4GfkLh1FE7pq44SWt76vK2Bw==",
+            "license": "MIT"
+        },
+        "node_modules/terra-draw-google-maps-adapter": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/terra-draw-google-maps-adapter/-/terra-draw-google-maps-adapter-1.6.1.tgz",
+            "integrity": "sha512-YCmMaOUSnltFcRdCTPwfOgb6CMGLK2gIGwuf7Iuk0sX1dzwChpMZWyEhIJDMJeg0f6gN3XNn1OpOz4jfKCQRBQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@googlemaps/js-api-loader": "^1.14.3 || ^2.0.0",
+                "terra-draw": "^1.0.0"
             }
         },
         "node_modules/thememirror": {

--- a/modules/gui/package.json
+++ b/modules/gui/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "sepal": "../../lib/js/shared",
         "@casbin/expression-eval": "^5.3.0",
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-javascript": "^6.2.5",
@@ -60,6 +59,9 @@
         "redux": "5.0.1",
         "remark-gfm": "^4.0.1",
         "rxjs": "7.8.2",
+        "sepal": "../../lib/js/shared",
+        "terra-draw": "^1.32.3",
+        "terra-draw-google-maps-adapter": "^1.6.1",
         "thememirror": "^2.0.1"
     },
     "scripts": {

--- a/modules/gui/src/app/home/body/process/recipe/mosaic/panels/aoi/polygonSection.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/mosaic/panels/aoi/polygonSection.jsx
@@ -27,17 +27,25 @@ class _PolygonSection extends React.Component {
     }
 
     componentDidMount() {
-        const {map, inputs: {polygon}} = this.props
-        map.enablePolygonDrawing(drawnPolygon => {
-            polygon.set(drawnPolygon)
-        })
+        const {map, recipeActionBuilder, inputs: {polygon}} = this.props
+        recipeActionBuilder('SET_AOI_EDITING')
+            .set('ui.aoi.editing', true)
+            .dispatch()
+        // Read lazily: the map re-runs this on layout change, and a captured value would revert edits.
+        map.enablePolygonDrawing(
+            drawnPolygon => polygon.set(drawnPolygon),
+            () => this.props.inputs.polygon.value
+        )
     }
 
     componentWillUnmount() {
-        const {map} = this.props
+        const {map, recipeActionBuilder} = this.props
         this.boundsChanged$.next()
         this.boundsChanged$.complete()
         map.disablePolygonDrawing()
+        recipeActionBuilder('CLEAR_AOI_EDITING')
+            .del('ui.aoi.editing')
+            .dispatch()
     }
 
     render() {

--- a/modules/gui/src/app/home/map/aoiLayer.jsx
+++ b/modules/gui/src/app/home/map/aoiLayer.jsx
@@ -1,3 +1,5 @@
+import {selectFrom} from '~/stateUtils'
+
 import {AoiGeometryLayer} from './aoiGeometryLayer'
 import {EETableLayer} from './eeTableLayer'
 import {PolygonLayer} from './polygonLayer'
@@ -22,7 +24,15 @@ export const countryToEETable = aoi => ({
     fillColor
 })
 
+// While a polygon is being edited the applied aoi would sit under it. Only the fallback is suppressed:
+// a layer given an aoi of its own, as the panel's preview map is, still renders.
+export const isAoiSuppressed = ({layerConfig = {}, recipe}) =>
+    !layerConfig.aoi && !!selectFrom(recipe, 'ui.aoi.editing')
+
 export const AoiLayer = ({id, layerConfig = {}, layerIndex, map, recipe}) => {
+    if (isAoiSuppressed({layerConfig, recipe})) {
+        return null
+    }
     const aoi = layerConfig.aoi || recipe.model.aoi || {}
     switch (aoi.type) {
         case 'COUNTRY': return (

--- a/modules/gui/src/app/home/map/aoiLayer.test.js
+++ b/modules/gui/src/app/home/map/aoiLayer.test.js
@@ -1,0 +1,27 @@
+import {isAoiSuppressed} from './aoiLayer'
+
+const editing = {ui: {aoi: {editing: true}}}
+const idle = {ui: {}}
+const ownAoi = {aoi: {type: 'POLYGON', path: [[10, 20], [30, 20], [30, 40]]}}
+
+describe('isAoiSuppressed', () => {
+    it('suppresses the applied aoi while a polygon is being edited', () => {
+        expect(isAoiSuppressed({layerConfig: {}, recipe: editing})).toBe(true)
+    })
+
+    it('keeps rendering a layer given an aoi of its own, so the preview map survives', () => {
+        expect(isAoiSuppressed({layerConfig: ownAoi, recipe: editing})).toBe(false)
+    })
+
+    it('renders normally when nothing is being edited', () => {
+        expect(isAoiSuppressed({layerConfig: {}, recipe: idle})).toBe(false)
+    })
+
+    it('renders normally when the recipe carries no ui state at all', () => {
+        expect(isAoiSuppressed({layerConfig: {}, recipe: {}})).toBe(false)
+    })
+
+    it('defaults a missing layerConfig to no aoi of its own', () => {
+        expect(isAoiSuppressed({recipe: editing})).toBe(true)
+    })
+})

--- a/modules/gui/src/app/home/map/drawing.js
+++ b/modules/gui/src/app/home/map/drawing.js
@@ -1,0 +1,51 @@
+const ring = ({geometry: {coordinates}}) => coordinates[0]
+
+const isClosed = ring => {
+    if (ring.length < 2) {
+        return false
+    }
+    const [firstLng, firstLat] = ring[0]
+    const [lastLng, lastLat] = ring[ring.length - 1]
+    return firstLng === lastLng && firstLat === lastLat
+}
+
+// An aoi path is stored open, the way the Google Maps drawing library handed it over.
+export const toPolygonPath = feature => {
+    const coordinates = ring(feature)
+    return isClosed(coordinates)
+        ? coordinates.slice(0, -1)
+        : coordinates
+}
+
+// TerraDrawPolygonMode matches on `mode` to decide a feature is its own, and so editable.
+export const toPolygonFeature = path => ({
+    type: 'Feature',
+    properties: {mode: 'polygon'},
+    geometry: {
+        type: 'Polygon',
+        coordinates: [isClosed(path) ? path : [...path, path[0]]]
+    }
+})
+
+export const toBounds = feature => {
+    const coordinates = ring(feature)
+    const lngs = coordinates.map(([lng]) => lng)
+    const lats = coordinates.map(([, lat]) => lat)
+    return [
+        [Math.min(...lngs), Math.min(...lats)],
+        [Math.max(...lngs), Math.max(...lats)]
+    ]
+}
+
+// TerraDrawGoogleMapsAdapter reads these straight off the namespace it is handed, but half of them
+// live under `core` in the namespace maps.jsx assembles, so it gets a flattened view instead.
+export const ADAPTER_MEMBERS = ['Data', 'LatLng', 'LatLngBounds', 'OverlayView', 'Point', 'Size']
+
+export const toAdapterLib = google => ({...google.maps, ...google.maps.core})
+
+// Polygons only: with showCoordinatePoints on, vertices are Point features in the same store, owned
+// by bookkeeping the mode keeps privately, and deleting those leaves it holding dead ids.
+export const otherPolygonIds = (features, keepId) =>
+    features
+        .filter(({id, geometry}) => id !== keepId && geometry.type === 'Polygon')
+        .map(({id}) => id)

--- a/modules/gui/src/app/home/map/drawing.test.js
+++ b/modules/gui/src/app/home/map/drawing.test.js
@@ -1,0 +1,107 @@
+import {ADAPTER_MEMBERS, otherPolygonIds, toAdapterLib, toBounds, toPolygonFeature, toPolygonPath} from './drawing'
+
+const rectangle = ([west, south], [east, north]) => feature([
+    [west, south], [east, south], [east, north], [west, north], [west, south]
+])
+
+const feature = coordinates => ({
+    type: 'Feature',
+    properties: {mode: 'polygon'},
+    geometry: {type: 'Polygon', coordinates: [coordinates]}
+})
+
+describe('toPolygonPath', () => {
+    it('drops the closing vertex GeoJSON rings carry', () => {
+        expect(toPolygonPath(feature([[10, 20], [30, 20], [30, 40], [10, 20]])))
+            .toEqual([[10, 20], [30, 20], [30, 40]])
+    })
+
+    it('leaves an already-open ring untouched', () => {
+        expect(toPolygonPath(feature([[10, 20], [30, 20], [30, 40]])))
+            .toEqual([[10, 20], [30, 20], [30, 40]])
+    })
+
+    it('keeps coordinates in lng/lat order', () => {
+        expect(toPolygonPath(feature([[-58.4, -34.6], [2.3, 48.9], [139.7, 35.7], [-58.4, -34.6]])))
+            .toEqual([[-58.4, -34.6], [2.3, 48.9], [139.7, 35.7]])
+    })
+})
+
+describe('toBounds', () => {
+    it('returns south-west and north-east corners', () => {
+        expect(toBounds(rectangle([10, 20], [30, 40])))
+            .toEqual([[10, 20], [30, 40]])
+    })
+
+    it('is independent of the direction the rectangle was drawn in', () => {
+        expect(toBounds(rectangle([30, 40], [10, 20])))
+            .toEqual([[10, 20], [30, 40]])
+    })
+
+    it('handles bounds spanning the equator and prime meridian', () => {
+        expect(toBounds(rectangle([-10, -5], [15, 25])))
+            .toEqual([[-10, -5], [15, 25]])
+    })
+})
+
+describe('toAdapterLib', () => {
+    // Mirrors the namespace maps.jsx builds: the `maps` library spread flat, everything else nested.
+    const google = {maps: {
+        Data: 'Data',
+        OverlayView: 'OverlayView',
+        core: {LatLng: 'LatLng', LatLngBounds: 'LatLngBounds', Point: 'Point', Size: 'Size'},
+        marker: {}, places: {}, geocoding: {}
+    }}
+
+    it.each(ADAPTER_MEMBERS)('exposes %s, which the adapter reads off the namespace', member => {
+        expect(toAdapterLib(google)[member]).toBeDefined()
+    })
+
+    it('would not find the core members on the unflattened namespace', () => {
+        expect(google.maps.LatLng).toBeUndefined()
+    })
+})
+
+describe('otherPolygonIds', () => {
+    const polygon = id => ({id, geometry: {type: 'Polygon'}})
+    const point = id => ({id, geometry: {type: 'Point'}})
+
+    it('lists the polygons that are not the one being kept', () => {
+        expect(otherPolygonIds([polygon('a'), polygon('b'), polygon('c')], 'c')).toEqual(['a', 'b'])
+    })
+
+    it('never lists coordinate points, which the mode owns', () => {
+        expect(otherPolygonIds([polygon('a'), point('a1'), point('a2')], 'a')).toEqual([])
+    })
+
+    it('leaves the kept polygon\'s own points alone while listing an older polygon', () => {
+        expect(otherPolygonIds([polygon('old'), point('old1'), polygon('new'), point('new1')], 'new'))
+            .toEqual(['old'])
+    })
+
+    it('lists nothing for an empty store', () => {
+        expect(otherPolygonIds([], 'a')).toEqual([])
+    })
+})
+
+describe('toPolygonFeature', () => {
+    const path = [[10, 20], [30, 20], [30, 40]]
+
+    it('closes the ring GeoJSON requires', () => {
+        expect(toPolygonFeature(path).geometry.coordinates[0])
+            .toEqual([[10, 20], [30, 20], [30, 40], [10, 20]])
+    })
+
+    it('does not double the closing vertex of an already-closed path', () => {
+        expect(toPolygonFeature([...path, [10, 20]]).geometry.coordinates[0])
+            .toEqual([[10, 20], [30, 20], [30, 40], [10, 20]])
+    })
+
+    it('tags the feature as a polygon-mode feature, which is what makes it editable', () => {
+        expect(toPolygonFeature(path).properties.mode).toBe('polygon')
+    })
+
+    it('round-trips through toPolygonPath', () => {
+        expect(toPolygonPath(toPolygonFeature(path))).toEqual(path)
+    })
+})

--- a/modules/gui/src/app/home/map/map.jsx
+++ b/modules/gui/src/app/home/map/map.jsx
@@ -447,12 +447,12 @@ class _Map extends React.Component {
 
     // Polygon
 
-    enablePolygonDrawing(callback) {
+    enablePolygonDrawing(callback, getPath) {
         log.debug('enablePolygonDrawing')
         this.enterDrawingMode('polygon', ({map}) =>
             map.enablePolygonDrawing((...args) => {
                 callback && callback(...args)
-            })
+            }, getPath)
         )
     }
 

--- a/modules/gui/src/app/home/map/maps.jsx
+++ b/modules/gui/src/app/home/map/maps.jsx
@@ -18,8 +18,9 @@ import {SepalMap} from './sepalMap'
 const log = getLogger('maps')
 
 // Note: Google Maps API v.3.5+ deprecates Marker for AdvancedMarkerElement, which requires creating a MapId
-const GOOGLE_MAPS_VERSION = '3.62'
-const GOOGLE_MAPS_LIBRARIES = ['core', 'drawing', 'geocoding', 'marker', 'places']
+// Note: a retired numbered version silently falls back to the weekly channel, so a channel is pinned
+const GOOGLE_MAPS_VERSION = 'quarterly'
+const GOOGLE_MAPS_LIBRARIES = ['core', 'geocoding', 'marker', 'places']
 
 const DEFAULT_ZOOM = 3
 export const MIN_ZOOM = 3
@@ -80,8 +81,8 @@ class _Maps extends React.Component {
         )
 
         return forkJoin(libraries).pipe(
-            map(({core, maps, marker, drawing, places, geocoding}) =>
-                ({google: {maps: {...maps, core, marker, drawing, places, geocoding}, googleMapsApiKey}})
+            map(({core, maps, marker, places, geocoding}) =>
+                ({google: {maps: {...maps, core, marker, places, geocoding}, googleMapsApiKey}})
             )
         )
     }

--- a/modules/gui/src/app/home/map/sepalMap.js
+++ b/modules/gui/src/app/home/map/sepalMap.js
@@ -1,7 +1,11 @@
 import _ from 'lodash'
 import {Subject} from 'rxjs'
+import {TerraDraw, TerraDrawPolygonMode, TerraDrawRectangleMode} from 'terra-draw'
+import {TerraDrawGoogleMapsAdapter} from 'terra-draw-google-maps-adapter'
 
 import {getLogger} from '~/log'
+
+import {otherPolygonIds, toAdapterLib, toBounds, toPolygonFeature, toPolygonPath} from './drawing'
 
 const log = getLogger('sepalMap')
 
@@ -105,8 +109,8 @@ export class SepalMap {
         editable: false,
         zIndex: 1
     }
-    drawingManager = null
-    drawingPolygon = null
+    drawing = null
+    drawingListener = null
 
     getGoogle() {
         return {
@@ -137,19 +141,86 @@ export class SepalMap {
 
     // Drawing mode
 
-    enableDrawingMode(options, callback) {
+    drawingStyles() {
+        const {fillColor, fillOpacity, strokeColor, strokeWeight} = this.drawingOptions
+        return {fillColor, fillOpacity, outlineColor: strokeColor, outlineWidth: strokeWeight}
+    }
+
+    // Rectangle styling accepts the four shared keys only, so the vertex markers stay polygon-only.
+    polygonStyles() {
+        const styles = this.drawingStyles()
+        return {
+            ...styles,
+            coordinatePointColor: styles.fillColor,
+            coordinatePointOutlineColor: styles.outlineColor,
+            coordinatePointWidth: 5,
+            coordinatePointOutlineWidth: 1
+        }
+    }
+
+    getDrawing() {
         const {google, googleMap} = this
+        if (!this.drawing) {
+            const lib = toAdapterLib(google)
+            this.drawing = new TerraDraw({
+                adapter: new TerraDrawGoogleMapsAdapter({lib, map: googleMap}),
+                modes: [
+                    new TerraDrawPolygonMode({
+                        styles: this.polygonStyles(),
+                        editable: true,
+                        showCoordinatePoints: true
+                    }),
+                    new TerraDrawRectangleMode({styles: this.drawingStyles()})
+                ]
+            })
+        }
+        return this.drawing
+    }
+
+    // Starts the store over rather than deleting the older polygon in place, which would strand its
+    // vertex points: there is no afterFeatureDeleted hook to clean them up.
+    retainOnly(drawing, feature) {
+        if (!feature || !otherPolygonIds(drawing.getSnapshot(), feature.id).length) {
+            return
+        }
+        drawing.clear()
+        drawing.addFeatures([toPolygonFeature(toPolygonPath(feature))])
+    }
+
+    enableDrawingMode(mode, callback, {retain = false} = {}) {
         this.disableDrawingMode()
-        this.drawingManager = new google.maps.drawing.DrawingManager(options)
-        google.maps.core.event.addListener(this.drawingManager, 'overlaycomplete', callback)
-        this.drawingManager.setMap(googleMap)
+        const drawing = this.getDrawing()
+        // Editing an existing shape finishes too, as an 'edit' or 'deleteCoordinate'.
+        this.drawingListener = id => {
+            const feature = drawing.getSnapshotFeature(id)
+            if (retain) {
+                this.retainOnly(drawing, feature)
+            } else {
+                drawing.clear()
+            }
+            if (feature) {
+                callback(feature)
+            } else {
+                log.warn(`Drawn feature ${id} is missing from the store`)
+            }
+        }
+        drawing.on('finish', this.drawingListener)
+        if (!drawing.enabled) {
+            drawing.start()
+        }
+        drawing.setMode(mode)
     }
 
     disableDrawingMode() {
-        const {google} = this
-        if (this.drawingManager) {
-            this.drawingManager.setMap(null)
-            google.maps.core.event.clearListeners(this.drawingManager, 'overlaycomplete')
+        const {drawing, drawingListener} = this
+        if (drawing) {
+            if (drawingListener) {
+                drawing.off('finish', drawingListener)
+                this.drawingListener = null
+            }
+            if (drawing.enabled) {
+                drawing.stop()
+            }
         }
     }
 
@@ -248,20 +319,10 @@ export class SepalMap {
     }
 
     enableZoomArea(callback) {
-        const {google, googleMap} = this
         log.debug('enableZoomArea')
-        this.enableDrawingMode({
-            drawingMode: google.maps.drawing.OverlayType.RECTANGLE,
-            drawingControl: false,
-            rectangleOptions: this.drawingOptions
-        }, ({type, overlay: rectangle}) => {
-            if (type === 'rectangle') {
-                rectangle.setMap(null)
-                googleMap.fitBounds(rectangle.bounds)
-                callback()
-            } else {
-                log.warn(`Expecting overlaycomplete event type rectangle but got ${type}`)
-            }
+        this.enableDrawingMode('rectangle', feature => {
+            this.fitBounds(toBounds(feature))
+            callback()
         })
     }
 
@@ -272,28 +333,17 @@ export class SepalMap {
 
     // Polygon
 
-    enablePolygonDrawing(callback) {
-        const {google} = this
+    enablePolygonDrawing(callback, getPath) {
         log.debug('enablePolygonDrawing')
-        this.enableDrawingMode({
-            drawingMode: google.maps.drawing.OverlayType.POLYGON,
-            drawingControl: false,
-            drawingControlOptions: {
-                position: google.maps.core.ControlPosition.TOP_CENTER,
-                drawingModes: ['polygon']
-            },
-            polygonOptions: this.drawingOptions,
-        }, ({type, overlay: polygon}) => {
-            if (type === 'polygon') {
-                polygon.setMap(null)
-                const toPolygonPath = polygon => polygon.getPaths().getArray()[0].getArray().map(latLng =>
-                    [latLng.lng(), latLng.lat()]
-                )
-                callback(toPolygonPath(polygon))
-            } else {
-                log.warn(`Expecting overlaycomplete event type polygon but got ${type}`)
+        this.enableDrawingMode('polygon', feature => callback(toPolygonPath(feature)), {retain: true})
+        const path = getPath && getPath()
+        if (path?.length) {
+            // Rejected features are dropped rather than thrown, so the aoi would just be absent.
+            const [validation] = this.drawing.addFeatures([toPolygonFeature(path)])
+            if (validation && !validation.valid) {
+                log.warn(`Saved polygon could not be loaded for editing: ${validation.reason}`)
             }
-        })
+        }
     }
 
     disablePolygonDrawing() {


### PR DESCRIPTION
Drawing a polygon AOI or a zoom area currently throws `DrawingManager ... is no longer available`. Google removed the Drawing Library in Maps JS 3.65, and our `3.62` pin had itself been retired — a retired numbered version doesn't error, it silently falls back to the default channel, so we were already running 3.66. The pin moves to `quarterly`, which can't go stale the same way, and the `drawing` library is dropped from the loader.

Drawing is reimplemented on Terra Draw (Google's recommended replacement) behind the existing `SepalMap` API, so `map.jsx`, `mapZoom.jsx` and `mapToolbar.jsx` are untouched. One integration detail worth a look: the adapter reads `LatLng`/`LatLngBounds`/`Point`/`Size` straight off the namespace it's handed, but `maps.jsx` nests those under `core`, so `toAdapterLib` hands it a flattened view — there's a test pinning that, since a future reshape of that namespace would otherwise break drawing silently.

Polygon AOIs also became editable: reopening a recipe loads the saved path back onto the map with draggable vertices, and the applied AOI outline is hidden while editing so it doesn't sit under the shape being edited.

Behaviour changes reviewers should know about:
- Polygons finish with **Enter** or by clicking the first point. Terra Draw has no double-click finish, unlike DrawingManager.
- Zoom-area is now click-to-start / click-to-finish rather than click-drag.
- Adds `terra-draw` and `terra-draw-google-maps-adapter`.

Tested with `vitest` (996 pass, 24 new), `eslint`, a production build, and by hand in a dev environment — drawing, editing a reopened AOI, replacing a polygon, and the zoom-area tool.