### PR TITLE
Made the recipe type tag filter single-select

### DIFF
--- a/modules/gui/src/app/home/body/process/createRecipe.jsx
+++ b/modules/gui/src/app/home/body/process/createRecipe.jsx
@@ -21,6 +21,7 @@ import {Panel} from '~/widget/panel/panel'
 import {SearchBox} from '~/widget/searchBox'
 
 import styles from './createRecipe.module.css'
+import {filterRecipeTypes, IGNORE, nextTagFilter, recipeTypeTags} from './createRecipeFilter'
 import {getRecipeType} from './recipeTypeRegistry'
 
 const mapStateToProps = state => {
@@ -78,13 +79,14 @@ class _CreateRecipe extends React.Component {
         this.closePanel = this.closePanel.bind(this)
         this.showRecipeTypeInfo = this.showRecipeTypeInfo.bind(this)
         this.setTextFilter = this.setTextFilter.bind(this)
-        this.setTagsFilter = this.setTagsFilter.bind(this)
+        this.setTagFilter = this.setTagFilter.bind(this)
     }
 
     state = {
         selectedRecipeType: null,
         textFilterValues: [],
-        tagsFilter: []
+        tags: [],
+        tagFilter: IGNORE
     }
 
     render() {
@@ -212,17 +214,16 @@ class _CreateRecipe extends React.Component {
     }
 
     renderTagsFilter() {
-        const {tags, tagsFilter} = this.state
+        const {tags, tagFilter} = this.state
 
-        const recipeOptions = tags?.map(tag => ({
+        const recipeOptions = tags.map(tag => ({
             label: msg(`process.recipe.newRecipe.tags.${tag}`),
             value: tag
         }))
 
         const options = [{
             label: msg('process.recipe.newRecipe.tags.ALL'),
-            // value: null,
-            deselect: true
+            value: IGNORE
         }, ...recipeOptions]
 
         return (
@@ -231,9 +232,8 @@ class _CreateRecipe extends React.Component {
                 layout='horizontal'
                 spacing='tight'
                 options={options}
-                multiple
-                selected={tagsFilter}
-                onSelect={this.setTagsFilter}
+                selected={tagFilter}
+                onSelect={this.setTagFilter}
             />
         )
     }
@@ -275,39 +275,17 @@ class _CreateRecipe extends React.Component {
         this.setState({textFilterValues})
     }
 
-    setTagsFilter(tagsFilter) {
-        this.setState({tagsFilter})
+    setTagFilter(tagFilter) {
+        this.setState(({tagFilter: prevTagFilter}) => ({
+            tagFilter: nextTagFilter(tagFilter, prevTagFilter)
+        }))
     }
 
     getFilteredRecipeTypes() {
         const {recipeTypes} = this.props
-        const {textFilterValues} = this.state
-        const searchMatchers = textFilterValues.map(filter => RegExp(filter, 'i'))
-        return _.chain(recipeTypes)
+        const {textFilterValues, tagFilter} = this.state
+        return filterRecipeTypes({recipeTypes, textFilterValues, tagFilter})
             .map(({id, labels, tags, beta}) => ({id, labels, tags, beta}))
-            .filter(recipeType => this.recipeTypeMatchesFilters(recipeType, searchMatchers))
-            .value()
-    }
-
-    recipeTypeMatchesFilters(recipeType, searchMatchers) {
-        return this.recipeTypeMatchesFilterValues(recipeType, searchMatchers)
-            && this.recipeTypeMatchesTags(recipeType)
-    }
-
-    recipeTypeMatchesFilterValues(recipeType, searchMatchers) {
-        const searchProperties = ['labels.name', 'labels.creationDescription']
-        return searchMatchers.length
-            ? _.every(searchMatchers, matcher =>
-                _.find(searchProperties, property =>
-                    matcher.test(simplifyString(_.get(recipeType, property)))
-                )
-            )
-            : true
-    }
-
-    recipeTypeMatchesTags(recipeType) {
-        const {tagsFilter} = this.state
-        return _.every(tagsFilter, tag => recipeType?.tags?.includes(tag))
     }
 
     getHighlightMatcher() {
@@ -317,13 +295,7 @@ class _CreateRecipe extends React.Component {
 
     updateTags() {
         const {recipeTypes} = this.props
-        const tags = _.chain(recipeTypes)
-            .map(({tags}) => tags)
-            .flatten()
-            .uniq()
-            .compact()
-            .value()
-        this.setState({tags})
+        this.setState({tags: recipeTypeTags(recipeTypes)})
     }
 
     componentDidMount() {

--- a/modules/gui/src/app/home/body/process/createRecipe.jsx
+++ b/modules/gui/src/app/home/body/process/createRecipe.jsx
@@ -21,7 +21,7 @@ import {Panel} from '~/widget/panel/panel'
 import {SearchBox} from '~/widget/searchBox'
 
 import styles from './createRecipe.module.css'
-import {filterRecipeTypes, IGNORE, nextTagFilter, recipeTypeTags} from './createRecipeFilter'
+import {filterRecipeTypes, IGNORE, nextTagFilter, noFilters, recipeTypeTags} from './createRecipeFilter'
 import {getRecipeType} from './recipeTypeRegistry'
 
 const mapStateToProps = state => {
@@ -84,9 +84,8 @@ class _CreateRecipe extends React.Component {
 
     state = {
         selectedRecipeType: null,
-        textFilterValues: [],
         tags: [],
-        tagFilter: IGNORE
+        ...noFilters()
     }
 
     render() {
@@ -202,10 +201,8 @@ class _CreateRecipe extends React.Component {
     }
 
     renderSearch() {
-        const {filterValue} = this.props
         return (
             <SearchBox
-                value={filterValue}
                 placeholder={msg('process.recipe.newRecipe.search.placeholder')}
                 debounce={0}
                 onSearchValue={this.setTextFilter}
@@ -281,6 +278,10 @@ class _CreateRecipe extends React.Component {
         }))
     }
 
+    resetFilters() {
+        this.setState(noFilters())
+    }
+
     getFilteredRecipeTypes() {
         const {recipeTypes} = this.props
         const {textFilterValues, tagFilter} = this.state
@@ -302,10 +303,14 @@ class _CreateRecipe extends React.Component {
         this.updateTags()
     }
 
-    componentDidUpdate({recipeTypes: prevRecipeTypes}) {
-        const {recipeTypes} = this.props
+    componentDidUpdate({recipeTypes: prevRecipeTypes, panel: prevPanel}) {
+        const {recipeTypes, panel} = this.props
         if (!_.isEqual(recipeTypes, prevRecipeTypes)) {
             this.updateTags()
+        }
+        // The component outlives the panel, so its filters have to be cleared explicitly.
+        if (prevPanel && !panel) {
+            this.resetFilters()
         }
     }
 }

--- a/modules/gui/src/app/home/body/process/createRecipeFilter.js
+++ b/modules/gui/src/app/home/body/process/createRecipeFilter.js
@@ -19,6 +19,12 @@ export const recipeTypeTags = recipeTypes =>
 export const nextTagFilter = (tagFilter, prevTagFilter) =>
     tagFilter !== prevTagFilter ? tagFilter : IGNORE
 
+// The panel's cleared state, reapplied every time it closes.
+export const noFilters = () => ({
+    textFilterValues: [],
+    tagFilter: IGNORE
+})
+
 const matchesTagFilter = (recipeType, tagFilter) =>
     tagFilter === IGNORE || !!recipeType.tags?.includes(tagFilter)
 

--- a/modules/gui/src/app/home/body/process/createRecipeFilter.js
+++ b/modules/gui/src/app/home/body/process/createRecipeFilter.js
@@ -1,0 +1,37 @@
+import _ from 'lodash'
+
+import {simplifyString} from '~/string'
+
+// Sentinel for the "All" chip: a tag filter that matches every recipe type.
+export const IGNORE = 'IGNORE'
+
+const SEARCH_PROPERTIES = ['labels.name', 'labels.creationDescription']
+
+export const recipeTypeTags = recipeTypes =>
+    _.chain(recipeTypes)
+        .map(({tags}) => tags)
+        .flatten()
+        .uniq()
+        .compact()
+        .value()
+
+// Picking the selected chip again clears the filter, matching the apps tag filter.
+export const nextTagFilter = (tagFilter, prevTagFilter) =>
+    tagFilter !== prevTagFilter ? tagFilter : IGNORE
+
+const matchesTagFilter = (recipeType, tagFilter) =>
+    tagFilter === IGNORE || !!recipeType.tags?.includes(tagFilter)
+
+const matchesSearchMatchers = (recipeType, searchMatchers) =>
+    _.every(searchMatchers, matcher =>
+        _.find(SEARCH_PROPERTIES, property =>
+            matcher.test(simplifyString(_.get(recipeType, property)))
+        )
+    )
+
+export const filterRecipeTypes = ({recipeTypes, textFilterValues = [], tagFilter}) => {
+    const searchMatchers = textFilterValues.map(filter => RegExp(filter, 'i'))
+    return recipeTypes.filter(recipeType =>
+        matchesSearchMatchers(recipeType, searchMatchers) && matchesTagFilter(recipeType, tagFilter)
+    )
+}

--- a/modules/gui/src/app/home/body/process/createRecipeFilter.test.js
+++ b/modules/gui/src/app/home/body/process/createRecipeFilter.test.js
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {filterRecipeTypes, IGNORE, nextTagFilter, recipeTypeTags} from './createRecipeFilter'
+import {filterRecipeTypes, IGNORE, nextTagFilter, noFilters, recipeTypeTags} from './createRecipeFilter'
 
 // Mirrors the real registry: shared tags, multiple tags, and recipe types
 // declaring no tags at all (bandMath, classification, remapping, ...).
@@ -60,5 +60,15 @@ describe('nextTagFilter', () => {
 
     it('stays unfiltered when the "All" chip is picked again', () => {
         expect(nextTagFilter(IGNORE, IGNORE)).toBe(IGNORE)
+    })
+})
+
+describe('noFilters', () => {
+    it('is a state the filter treats as showing everything', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, ...noFilters()}))).toEqual(['MOSAIC', 'RADAR_MOSAIC', 'CHANGE_ALERTS', 'CLASSIFICATION'])
+    })
+
+    it('hands out a fresh text filter array each time, so resets cannot alias', () => {
+        expect(noFilters().textFilterValues).not.toBe(noFilters().textFilterValues)
     })
 })

--- a/modules/gui/src/app/home/body/process/createRecipeFilter.test.js
+++ b/modules/gui/src/app/home/body/process/createRecipeFilter.test.js
@@ -1,0 +1,64 @@
+import {describe, expect, it} from 'vitest'
+
+import {filterRecipeTypes, IGNORE, nextTagFilter, recipeTypeTags} from './createRecipeFilter'
+
+// Mirrors the real registry: shared tags, multiple tags, and recipe types
+// declaring no tags at all (bandMath, classification, remapping, ...).
+const OPTICAL_MOSAIC = {id: 'MOSAIC', labels: {name: 'Optical mosaic', creationDescription: 'Multiple scenes into one'}, tags: ['MOSAIC']}
+const RADAR_MOSAIC = {id: 'RADAR_MOSAIC', labels: {name: 'Radar mosaic', creationDescription: 'Multiple scenes into one'}, tags: ['MOSAIC']}
+const CHANGE_ALERTS = {id: 'CHANGE_ALERTS', labels: {name: 'Change alerts', creationDescription: 'Detect changes over time'}, tags: ['CHANGE', 'ALERTS']}
+const CLASSIFICATION = {id: 'CLASSIFICATION', labels: {name: 'Classification', creationDescription: 'Classify imagery'}}
+
+const recipeTypes = [OPTICAL_MOSAIC, RADAR_MOSAIC, CHANGE_ALERTS, CLASSIFICATION]
+
+const ids = result => result.map(({id}) => id)
+
+describe('filterRecipeTypes', () => {
+    it('matches a recipe type by any one of its tags', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: 'CHANGE'}))).toEqual(['CHANGE_ALERTS'])
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: 'ALERTS'}))).toEqual(['CHANGE_ALERTS'])
+    })
+
+    it('returns every recipe type, tagged or not, when no tag is selected', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: IGNORE}))).toEqual(['MOSAIC', 'RADAR_MOSAIC', 'CHANGE_ALERTS', 'CLASSIFICATION'])
+    })
+
+    it('excludes recipe types declaring no tags when a tag is selected', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: 'MOSAIC'}))).toEqual(['MOSAIC', 'RADAR_MOSAIC'])
+    })
+
+    it('matches recipe types on both name and creation description', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: IGNORE, textFilterValues: ['mosaic']}))).toEqual(['MOSAIC', 'RADAR_MOSAIC'])
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: IGNORE, textFilterValues: ['scenes']}))).toEqual(['MOSAIC', 'RADAR_MOSAIC'])
+    })
+
+    it('requires every search term to match', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: IGNORE, textFilterValues: ['radar', 'mosaic']}))).toEqual(['RADAR_MOSAIC'])
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: IGNORE, textFilterValues: ['radar', 'change']}))).toEqual([])
+    })
+
+    it('requires a match on the text filter and the tag filter alike', () => {
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: 'CHANGE', textFilterValues: ['alerts']}))).toEqual(['CHANGE_ALERTS'])
+        expect(ids(filterRecipeTypes({recipeTypes, tagFilter: 'MOSAIC', textFilterValues: ['alerts']}))).toEqual([])
+    })
+})
+
+describe('recipeTypeTags', () => {
+    it('lists each distinct tag once, in registry order, ignoring untagged recipe types', () => {
+        expect(recipeTypeTags(recipeTypes)).toEqual(['MOSAIC', 'CHANGE', 'ALERTS'])
+    })
+})
+
+describe('nextTagFilter', () => {
+    it('replaces the selected tag rather than adding to it', () => {
+        expect(nextTagFilter('CHANGE', 'MOSAIC')).toBe('CHANGE')
+    })
+
+    it('clears back to no filter when the selected tag is picked again', () => {
+        expect(nextTagFilter('CHANGE', 'CHANGE')).toBe(IGNORE)
+    })
+
+    it('stays unfiltered when the "All" chip is picked again', () => {
+        expect(nextTagFilter(IGNORE, IGNORE)).toBe(IGNORE)
+    })
+})


### PR DESCRIPTION
The Add recipe tag chips were multi-select with AND matching, so any combination other than change+alerts matched nothing — #340 has a screenshot of four chips lit over an empty list. They are single-select now, mirroring the apps tag filter in `appList.jsx`: an `IGNORE` sentinel on "All", a scalar selection, and re-clicking the active chip returning to "All". `widget/buttons.jsx` already supported single-select, so it is untouched. The filter logic moved into a pure `createRecipeFilter.js` with unit coverage.

The second commit fixes a related bug found on the way: `_CreateRecipe` outlives the panel it renders, so both filters survived a close. That was invisible for the text search, which reseeds empty on reopen while the list stayed filtered — `renderSearch` read a `filterValue` prop that `mapStateToProps` never supplied. Both filters now clear when the panel closes.

Fixes #340.