### PR TITLE
Fix Terra Draw pane synchronization

### DIFF
--- a/modules/gui/src/app/home/map/drawing.js
+++ b/modules/gui/src/app/home/map/drawing.js
@@ -1,5 +1,7 @@
 const ring = ({geometry: {coordinates}}) => coordinates[0]
 
+export const DRAWING_COORDINATE_PRECISION = 9
+
 const isClosed = ring => {
     if (ring.length < 2) {
         return false
@@ -18,14 +20,23 @@ export const toPolygonPath = feature => {
 }
 
 // TerraDrawPolygonMode matches on `mode` to decide a feature is its own, and so editable.
-export const toPolygonFeature = path => ({
-    type: 'Feature',
-    properties: {mode: 'polygon'},
-    geometry: {
-        type: 'Polygon',
-        coordinates: [isClosed(path) ? path : [...path, path[0]]]
+export const toPolygonFeature = path => {
+    const normalizedPath = path.map(coordinate =>
+        coordinate.map(value => Number(value.toFixed(DRAWING_COORDINATE_PRECISION)))
+    )
+    return {
+        type: 'Feature',
+        properties: {mode: 'polygon'},
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                isClosed(normalizedPath)
+                    ? normalizedPath
+                    : [...normalizedPath, normalizedPath[0]]
+            ]
+        }
     }
-})
+}
 
 export const toBounds = feature => {
     const coordinates = ring(feature)

--- a/modules/gui/src/app/home/map/drawing.test.js
+++ b/modules/gui/src/app/home/map/drawing.test.js
@@ -1,4 +1,26 @@
+import {TerraDraw, TerraDrawPolygonMode} from 'terra-draw'
+
 import {ADAPTER_MEMBERS, otherPolygonIds, toAdapterLib, toBounds, toPolygonFeature, toPolygonPath} from './drawing'
+
+const createDrawing = () => {
+    const adapter = {
+        getCoordinatePrecision: () => 9,
+        project: (lng, lat) => ({x: lng, y: lat}),
+        unproject: (x, y) => ({lng: x, lat: y}),
+        setDoubleClickToZoom: () => {},
+        setCursor: () => {},
+        register: () => {},
+        unregister: () => {},
+        render: () => {},
+        clear: () => {},
+        setDraggability: () => {},
+        getLngLatFromEvent: () => null
+    }
+    const drawing = new TerraDraw({adapter, modes: [new TerraDrawPolygonMode()]})
+    drawing.start()
+    drawing.setMode('polygon')
+    return drawing
+}
 
 const rectangle = ([west, south], [east, north]) => feature([
     [west, south], [east, south], [east, north], [west, north], [west, south]
@@ -103,5 +125,19 @@ describe('toPolygonFeature', () => {
 
     it('round-trips through toPolygonPath', () => {
         expect(toPolygonPath(toPolygonFeature(path))).toEqual(path)
+    })
+
+    it('loads polygon paths saved by the previous Google drawing implementation', () => {
+        const legacyPath = [
+            [12.462927350619111, 41.87303911003311],
+            [12.462927350619111, 41.843888713632325],
+            [12.510992536165986, 41.846190543809854],
+            [12.51064921341208, 41.87303911003311],
+            [12.462927350619111, 41.87303911003311]
+        ]
+
+        const [validation] = createDrawing().addFeatures([toPolygonFeature(legacyPath)])
+
+        expect(validation.valid, validation.reason).toBe(true)
     })
 })

--- a/modules/gui/src/app/home/map/map.jsx
+++ b/modules/gui/src/app/home/map/map.jsx
@@ -50,7 +50,7 @@ const mapRecipeToProps = recipe => ({
 const OVERLAY_ID = 'overlay-layer-id'
 const OVERLAY_AREA = 'overlay-area'
 
-class _Map extends React.Component {
+export class _Map extends React.Component {
     viewUpdates$ = new BehaviorSubject({})
     linked$ = new BehaviorSubject(false)
     renderingEnabled$ = new BehaviorSubject(false)
@@ -450,8 +450,15 @@ class _Map extends React.Component {
     enablePolygonDrawing(callback, getPath) {
         log.debug('enablePolygonDrawing')
         this.enterDrawingMode('polygon', ({map}) =>
-            map.enablePolygonDrawing((...args) => {
-                callback && callback(...args)
+            map.enablePolygonDrawing(drawnPolygon => {
+                if (!this.isStackMode()) {
+                    this.withAreaMaps(({map: otherMap}) => {
+                        if (otherMap !== map) {
+                            otherMap.setPolygonDrawing(drawnPolygon)
+                        }
+                    })
+                }
+                callback && callback(drawnPolygon)
             }, getPath)
         )
     }

--- a/modules/gui/src/app/home/map/map.jsx
+++ b/modules/gui/src/app/home/map/map.jsx
@@ -61,6 +61,8 @@ export class _Map extends React.Component {
     draggingSplit$ = new BehaviorSubject(false)
     cursor$ = new Subject()
     drawingInstances = []
+    activePolygonDrawing = null
+    readyMaps = new WeakSet()
 
     filteredViewUpdates$ = this.viewUpdates$.pipe(
         distinctUntilChanged(_.isEqual)
@@ -194,6 +196,12 @@ export class _Map extends React.Component {
         )
     }
 
+    withReadyAreaMaps(func) {
+        return this.withAreaMaps(args =>
+            this.readyMaps.has(args.map) ? func(args) : null
+        )
+    }
+
     withFirstAreaMap(func) {
         const {maps} = this.state
         const id = _.head(_.keys(maps))
@@ -210,6 +218,12 @@ export class _Map extends React.Component {
             return func({id: OVERLAY_ID, map, listeners, subscriptions})
         }
         return null
+    }
+
+    withReadyOverlayMap(func) {
+        return this.withOverlayMap(args =>
+            this.readyMaps.has(args.map) ? func(args) : null
+        )
     }
 
     createMap(id, element, isOverlay, callback) {
@@ -232,10 +246,16 @@ export class _Map extends React.Component {
 
         const {googleMap} = map.getGoogle()
 
+        let ready = false
         const listeners = [
-            googleMap.addListener('idle',
-                () => this.viewChanged$.next()
-            ),
+            googleMap.addListener('idle', () => {
+                this.viewChanged$.next()
+                if (!ready) {
+                    ready = true
+                    this.readyMaps.add(map)
+                    this.enableDrawingModeOnMap(map, isOverlay)
+                }
+            }),
             googleMap.addListener('mouseout',
                 () => this.synchronizeCursor(id, null)
             ),
@@ -270,11 +290,20 @@ export class _Map extends React.Component {
 
     removeMap(id) {
         const {maps} = this.state
+        let restorePath
+        let restorePolygonDrawing = false
         if (maps[id]) {
             const {map, listeners, subscriptions} = maps[id]
             const {google} = map.getGoogle()
             const area = this.getArea(id)
             log.debug(() => `Removing ${mapTag(this.state.mapId, id)} from ${areaTag(area)}`)
+            if (this.activePolygonDrawing?.map === map) {
+                restorePath = this.activePolygonDrawing.getPath?.()
+                restorePolygonDrawing = true
+                this.activePolygonDrawing = null
+            }
+            map.disableDrawingMode()
+            this.readyMaps.delete(map)
             listeners.forEach(listener =>
                 google.maps.core.event.removeListener(listener)
             )
@@ -283,7 +312,12 @@ export class _Map extends React.Component {
             )
         }
         this.setState(
-            ({maps}) => ({maps: _.omit(maps, id)})
+            ({maps}) => ({maps: _.omit(maps, id)}),
+            () => {
+                if (restorePolygonDrawing) {
+                    this.withReadyAreaMaps(({map}) => map.setPolygonDrawing(restorePath))
+                }
+            }
         )
     }
 
@@ -354,6 +388,21 @@ export class _Map extends React.Component {
 
     // Drawing mode
 
+    enableDrawingModeOnMap(map, isOverlay) {
+        const activeInstance = _.last(this.drawingInstances)
+        const belongsToDrawingLayer = isOverlay ? this.isStackMode() : !this.isStackMode()
+        if (activeInstance && belongsToDrawingLayer) {
+            activeInstance.callback({map})
+            const activePolygonDrawing = this.activePolygonDrawing
+            if (activeInstance.drawingMode === 'polygon'
+                && !this.isStackMode()
+                && activePolygonDrawing
+                && activePolygonDrawing.map !== map) {
+                map.setPolygonPreview(activePolygonDrawing.path)
+            }
+        }
+    }
+
     enterDrawingMode(drawingMode, callback) {
         const newInstance = {drawingMode, callback}
         const currentInstance = _.last(this.drawingInstances)
@@ -385,15 +434,16 @@ export class _Map extends React.Component {
     reassignDrawingMode() {
         const activeInstance = _.last(this.drawingInstances)
         if (activeInstance) {
+            this.activePolygonDrawing = null
             const {drawingMode, callback} = activeInstance
             this.withAllMaps(({map}) => map.disableDrawingMode())
             if (this.isStackMode()) {
                 this.setState({drawingMode, overlayActive: true}, () => {
-                    this.withOverlayMap(callback)
+                    this.withReadyOverlayMap(callback)
                 })
             } else {
                 this.setState({drawingMode, overlayActive: false}, () => {
-                    this.withAreaMaps(callback)
+                    this.withReadyAreaMaps(callback)
                 })
             }
         }
@@ -403,17 +453,18 @@ export class _Map extends React.Component {
         log.debug('enableDrawingMode:', drawingMode)
         if (this.isStackMode()) {
             this.setState({drawingMode, overlayActive: true}, () => {
-                this.withOverlayMap(callback)
+                this.withReadyOverlayMap(callback)
             })
         } else {
             this.setState({drawingMode, overlayActive: false}, () => {
-                this.withAreaMaps(callback)
+                this.withReadyAreaMaps(callback)
             })
         }
     }
 
     disableDrawingMode() {
         log.debug('disableDrawingMode')
+        this.activePolygonDrawing = null
         if (this.isStackMode()) {
             this.setState({drawingMode: null, overlayActive: false}, () => {
                 this.withOverlayMap(({map}) => map.disableDrawingMode())
@@ -449,17 +500,34 @@ export class _Map extends React.Component {
 
     enablePolygonDrawing(callback, getPath) {
         log.debug('enablePolygonDrawing')
+        this.activePolygonDrawing = null
         this.enterDrawingMode('polygon', ({map}) =>
             map.enablePolygonDrawing(drawnPolygon => {
+                this.activePolygonDrawing = null
                 if (!this.isStackMode()) {
-                    this.withAreaMaps(({map: otherMap}) => {
+                    this.withReadyAreaMaps(({map: otherMap}) => {
                         if (otherMap !== map) {
                             otherMap.setPolygonDrawing(drawnPolygon)
                         }
                     })
                 }
                 callback && callback(drawnPolygon)
-            }, getPath)
+            }, getPath, drawnPolygon => {
+                if (!this.isStackMode()) {
+                    this.activePolygonDrawing = drawnPolygon?.length
+                        ? {map, path: drawnPolygon, getPath}
+                        : null
+                    this.withReadyAreaMaps(({map: otherMap}) => {
+                        if (drawnPolygon?.length) {
+                            if (otherMap !== map) {
+                                otherMap.setPolygonPreview(drawnPolygon)
+                            }
+                        } else {
+                            otherMap.setPolygonDrawing(getPath?.())
+                        }
+                    })
+                }
+            })
         )
     }
 
@@ -796,13 +864,12 @@ export class _Map extends React.Component {
         const previousAreaIds = Object.values(prevAreas).map(({id}) => id)
         const currentAreaIds = Object.values(areas).map(({id}) => id)
         const removedAreaIds = _.difference(previousAreaIds, currentAreaIds)
-        const addedAreaIds = _.difference(currentAreaIds, previousAreaIds)
         const modeChanged = prevMode !== mode
 
         if (removedAreaIds.length) {
             removedAreaIds.forEach(this.removeMap)
         }
-        if (addedAreaIds.length || modeChanged) {
+        if (modeChanged) {
             this.reassignDrawingMode()
         }
 

--- a/modules/gui/src/app/home/map/map.test.js
+++ b/modules/gui/src/app/home/map/map.test.js
@@ -2,17 +2,46 @@ import {_Map} from './map'
 
 const createPane = initialPath => ({
     path: initialPath,
-    enablePolygonDrawing(onFinish, getPath) {
+    previewPath: null,
+    enablePolygonDrawing(onFinish, getPath, onChange) {
         this.path = getPath()
+        this.changeDrawing = path => {
+            this.path = path
+            this.previewPath = null
+            onChange?.(path)
+        }
+        this.cancelDrawing = () => {
+            this.path = getPath()
+            onChange?.(null)
+        }
+        this.cancelDrawingWithoutCommitted = () => {
+            this.path = null
+            onChange?.(null)
+        }
         this.finishDrawing = path => {
             this.path = path
             onFinish(path)
         }
     },
+    setPolygonPreview(path) {
+        this.path = null
+        this.previewPath = path
+    },
     setPolygonDrawing(path) {
         this.path = path
+        this.previewPath = null
     }
 })
+
+const setStateSynchronously = map => {
+    map.setState = (update, callback) => {
+        const nextState = typeof update === 'function'
+            ? update(map.state, map.props)
+            : update
+        map.state = {...map.state, ...nextState}
+        callback?.()
+    }
+}
 
 describe('polygon drawing', () => {
     it('keeps the editable polygon synchronized across area maps', () => {
@@ -21,6 +50,7 @@ describe('polygon drawing', () => {
         const panes = [createPane(initialPath), createPane(initialPath), createPane(initialPath)]
         const map = new _Map({layers: {mode: 'grid'}})
         map.state.maps = Object.fromEntries(panes.map((pane, index) => [index, {map: pane}]))
+        map.readyMaps = new WeakSet(panes)
         map.enterDrawingMode = (_drawingMode, enable) =>
             map.withAreaMaps(enable)
 
@@ -32,5 +62,170 @@ describe('polygon drawing', () => {
 
         expect(panes.map(({path}) => path)).toEqual([updatedPath, updatedPath, updatedPath])
         expect(formPath).toEqual(updatedPath)
+    })
+
+    it('shows an unfinished polygon in every area map without updating the form', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const provisionalPath = [[11, 21], [31, 21], [31, 41]]
+        const panes = [createPane(initialPath), createPane(initialPath), createPane(initialPath)]
+        const map = new _Map({layers: {mode: 'grid'}})
+        map.state.maps = Object.fromEntries(panes.map((pane, index) => [index, {map: pane}]))
+        map.readyMaps = new WeakSet(panes)
+        map.enterDrawingMode = (_drawingMode, enable) =>
+            map.withAreaMaps(enable)
+
+        let formPath
+        map.enablePolygonDrawing(path => {
+            formPath = path
+        }, () => initialPath)
+        panes[0].changeDrawing(provisionalPath)
+
+        expect(panes.map(({path, previewPath}) => previewPath || path)).toEqual([
+            provisionalPath,
+            provisionalPath,
+            provisionalPath
+        ])
+        expect(formPath).toBeUndefined()
+    })
+
+    it('restores the committed polygon in every area map when drawing is cancelled', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const provisionalPath = [[11, 21], [31, 21], [31, 41]]
+        const panes = [createPane(initialPath), createPane(initialPath)]
+        const map = new _Map({layers: {mode: 'grid'}})
+        map.state.maps = Object.fromEntries(panes.map((pane, index) => [index, {map: pane}]))
+        map.readyMaps = new WeakSet(panes)
+        map.enterDrawingMode = (_drawingMode, enable) =>
+            map.withAreaMaps(enable)
+
+        let formPath
+        map.enablePolygonDrawing(path => {
+            formPath = path
+        }, () => initialPath)
+        panes[0].changeDrawing(provisionalPath)
+        panes[0].cancelDrawing()
+
+        expect(panes.map(({path, previewPath}) => previewPath || path)).toEqual([initialPath, initialPath])
+        expect(formPath).toBeUndefined()
+    })
+
+    it('restores the source pane when it cancels after taking over from a preview', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const firstDraft = [[11, 21], [31, 21], [31, 41]]
+        const secondDraft = [[12, 22], [32, 22], [32, 42]]
+        const panes = [createPane(initialPath), createPane(initialPath)]
+        const map = new _Map({layers: {mode: 'grid'}})
+        map.state.maps = Object.fromEntries(panes.map((pane, index) => [index, {map: pane}]))
+        map.readyMaps = new WeakSet(panes)
+        map.enterDrawingMode = (_drawingMode, enable) =>
+            map.withAreaMaps(enable)
+
+        map.enablePolygonDrawing(() => {}, () => initialPath)
+        panes[0].changeDrawing(firstDraft)
+        panes[1].changeDrawing(secondDraft)
+        panes[1].cancelDrawingWithoutCommitted()
+
+        expect(panes.map(({path, previewPath}) => previewPath || path)).toEqual([initialPath, initialPath])
+    })
+
+    it('starts polygon editing on an added pane after its first idle event', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const provisionalPath = [[11, 21], [31, 21], [31, 41]]
+        const googleMapListeners = {}
+        const googleMap = {
+            addListener(event, callback) {
+                googleMapListeners[event] = callback
+                return {event, callback}
+            },
+            setOptions() {}
+        }
+        const pane = {
+            ready: false,
+            enableCount: 0,
+            getGoogle: () => ({googleMap}),
+            getView: () => ({}),
+            enablePolygonDrawing(_onFinish, getPath) {
+                if (!this.ready) {
+                    throw new TypeError('Cannot read properties of null (reading \'addEventListener\')')
+                }
+                this.enableCount += 1
+                this.path = getPath()
+            },
+            setPolygonPreview(path) {
+                this.previewPath = path
+            },
+            disableDrawingMode() {}
+        }
+        const previousLayers = {mode: 'grid', areas: {left: {id: 'left'}}}
+        const layers = {...previousLayers, areas: {...previousLayers.areas, right: {id: 'right'}}}
+        const map = new _Map({
+            layers,
+            mapsContext: {createSepalMap: () => pane},
+            user: {manualMapRenderingEnabled: false}
+        })
+        map.scrollWheelEnabled$ = {
+            subscribe: callback => {
+                callback(true)
+                return {unsubscribe() {}}
+            }
+        }
+        setStateSynchronously(map)
+        map.drawingInstances = [{
+            drawingMode: 'polygon',
+            callback: ({map}) => map.enablePolygonDrawing(() => {}, () => initialPath)
+        }]
+        map.activePolygonDrawing = {map: {}, path: provisionalPath}
+        map.createMap('right', {}, false, entry => {
+            map.state.maps.right = {id: 'right', ...entry}
+        })
+
+        expect(() => map.componentDidUpdate({
+            layers: previousLayers,
+            user: {manualMapRenderingEnabled: false}
+        })).not.toThrow()
+        expect(pane.enableCount).toBe(0)
+
+        pane.ready = true
+        googleMapListeners.idle()
+        googleMapListeners.idle()
+
+        expect(pane.enableCount).toBe(1)
+        expect(pane.path).toEqual(initialPath)
+        expect(pane.previewPath).toEqual(provisionalPath)
+    })
+
+    it.each([
+        ['committed geometry', [[10, 20], [30, 20], [30, 40]]],
+        ['an empty path', undefined]
+    ])('restores %s when the active drawing pane is removed', (_description, initialPath) => {
+        const provisionalPath = [[11, 21], [31, 21], [31, 41]]
+        const source = createPane(initialPath)
+        const peer = createPane(initialPath)
+        const google = {maps: {core: {event: {removeListener() {}}}}}
+        source.getGoogle = () => ({google})
+        source.disableDrawingMode = () => {
+            source.drawingDisabled = true
+        }
+        peer.setPolygonPreview(provisionalPath)
+        const map = new _Map({
+            layers: {
+                mode: 'grid',
+                areas: {left: {id: 'left'}, right: {id: 'right'}}
+            }
+        })
+        map.state.maps = {
+            left: {map: source, listeners: [], subscriptions: []},
+            right: {map: peer, listeners: [], subscriptions: []}
+        }
+        map.readyMaps = new WeakSet([source, peer])
+        map.activePolygonDrawing = {map: source, path: provisionalPath, getPath: () => initialPath}
+        setStateSynchronously(map)
+
+        map.removeMap('left')
+
+        expect(source.drawingDisabled).toBe(true)
+        expect(map.activePolygonDrawing).toBeNull()
+        expect(peer.path).toEqual(initialPath)
+        expect(peer.previewPath).toBeNull()
     })
 })

--- a/modules/gui/src/app/home/map/map.test.js
+++ b/modules/gui/src/app/home/map/map.test.js
@@ -1,0 +1,36 @@
+import {_Map} from './map'
+
+const createPane = initialPath => ({
+    path: initialPath,
+    enablePolygonDrawing(onFinish, getPath) {
+        this.path = getPath()
+        this.finishDrawing = path => {
+            this.path = path
+            onFinish(path)
+        }
+    },
+    setPolygonDrawing(path) {
+        this.path = path
+    }
+})
+
+describe('polygon drawing', () => {
+    it('keeps the editable polygon synchronized across area maps', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const updatedPath = [[11, 21], [31, 21], [31, 41]]
+        const panes = [createPane(initialPath), createPane(initialPath), createPane(initialPath)]
+        const map = new _Map({layers: {mode: 'grid'}})
+        map.state.maps = Object.fromEntries(panes.map((pane, index) => [index, {map: pane}]))
+        map.enterDrawingMode = (_drawingMode, enable) =>
+            map.withAreaMaps(enable)
+
+        let formPath
+        map.enablePolygonDrawing(path => {
+            formPath = path
+        }, () => initialPath)
+        panes[1].finishDrawing(updatedPath)
+
+        expect(panes.map(({path}) => path)).toEqual([updatedPath, updatedPath, updatedPath])
+        expect(formPath).toEqual(updatedPath)
+    })
+})

--- a/modules/gui/src/app/home/map/sepalMap.js
+++ b/modules/gui/src/app/home/map/sepalMap.js
@@ -5,7 +5,14 @@ import {TerraDrawGoogleMapsAdapter} from 'terra-draw-google-maps-adapter'
 
 import {getLogger} from '~/log'
 
-import {otherPolygonIds, toAdapterLib, toBounds, toPolygonFeature, toPolygonPath} from './drawing'
+import {
+    DRAWING_COORDINATE_PRECISION,
+    otherPolygonIds,
+    toAdapterLib,
+    toBounds,
+    toPolygonFeature,
+    toPolygonPath
+} from './drawing'
 
 const log = getLogger('sepalMap')
 
@@ -163,7 +170,11 @@ export class SepalMap {
         if (!this.drawing) {
             const lib = toAdapterLib(google)
             this.drawing = new TerraDraw({
-                adapter: new TerraDrawGoogleMapsAdapter({lib, map: googleMap}),
+                adapter: new TerraDrawGoogleMapsAdapter({
+                    lib,
+                    map: googleMap,
+                    coordinatePrecision: DRAWING_COORDINATE_PRECISION
+                }),
                 modes: [
                     new TerraDrawPolygonMode({
                         styles: this.polygonStyles(),
@@ -185,6 +196,20 @@ export class SepalMap {
         }
         drawing.clear()
         drawing.addFeatures([toPolygonFeature(toPolygonPath(feature))])
+    }
+
+    setPolygonDrawing(path) {
+        const {drawing} = this
+        if (!path?.length) {
+            drawing.clear()
+            return
+        }
+        const [validation] = drawing.addFeatures([toPolygonFeature(path)])
+        if (validation.valid) {
+            this.retainOnly(drawing, drawing.getSnapshotFeature(validation.id))
+        } else {
+            log.warn(`Saved polygon could not be loaded for editing: ${validation.reason}`)
+        }
     }
 
     enableDrawingMode(mode, callback, {retain = false} = {}) {
@@ -219,6 +244,7 @@ export class SepalMap {
                 this.drawingListener = null
             }
             if (drawing.enabled) {
+                drawing.setMode('static')
                 drawing.stop()
             }
         }
@@ -337,13 +363,7 @@ export class SepalMap {
         log.debug('enablePolygonDrawing')
         this.enableDrawingMode('polygon', feature => callback(toPolygonPath(feature)), {retain: true})
         const path = getPath && getPath()
-        if (path?.length) {
-            // Rejected features are dropped rather than thrown, so the aoi would just be absent.
-            const [validation] = this.drawing.addFeatures([toPolygonFeature(path)])
-            if (validation && !validation.valid) {
-                log.warn(`Saved polygon could not be loaded for editing: ${validation.reason}`)
-            }
-        }
+        this.setPolygonDrawing(path)
     }
 
     disablePolygonDrawing() {

--- a/modules/gui/src/app/home/map/sepalMap.js
+++ b/modules/gui/src/app/home/map/sepalMap.js
@@ -118,6 +118,10 @@ export class SepalMap {
     }
     drawing = null
     drawingListener = null
+    drawingChangeListener = null
+    drawingChangesSuppressed = false
+    drawingFeatureId = null
+    polygonPreview = null
 
     getGoogle() {
         return {
@@ -198,25 +202,53 @@ export class SepalMap {
         drawing.addFeatures([toPolygonFeature(toPolygonPath(feature))])
     }
 
-    setPolygonDrawing(path) {
-        const {drawing} = this
-        if (!path?.length) {
-            drawing.clear()
-            return
-        }
-        const [validation] = drawing.addFeatures([toPolygonFeature(path)])
-        if (validation.valid) {
-            this.retainOnly(drawing, drawing.getSnapshotFeature(validation.id))
-        } else {
-            log.warn(`Saved polygon could not be loaded for editing: ${validation.reason}`)
+    clearPolygonPreview() {
+        if (this.polygonPreview) {
+            this.polygonPreview.setMap(null)
+            this.polygonPreview = null
         }
     }
 
-    enableDrawingMode(mode, callback, {retain = false} = {}) {
+    setPolygonPreview(path) {
+        if (!this.polygonPreview) {
+            this.drawingChangesSuppressed = true
+            try {
+                this.drawing.clear()
+            } finally {
+                this.drawingChangesSuppressed = false
+            }
+            this.polygonPreview = new this.google.maps.Polygon(this.drawingOptions)
+            this.polygonPreview.setMap(this.googleMap)
+        }
+        this.polygonPreview.setPath(path.map(([lng, lat]) => ({lng, lat})))
+    }
+
+    setPolygonDrawing(path) {
+        const {drawing} = this
+        this.clearPolygonPreview()
+        this.drawingChangesSuppressed = true
+        try {
+            if (!path?.length) {
+                drawing.clear()
+                return
+            }
+            const [validation] = drawing.addFeatures([toPolygonFeature(path)])
+            if (validation.valid) {
+                this.retainOnly(drawing, drawing.getSnapshotFeature(validation.id))
+            } else {
+                log.warn(`Saved polygon could not be loaded for editing: ${validation.reason}`)
+            }
+        } finally {
+            this.drawingChangesSuppressed = false
+        }
+    }
+
+    enableDrawingMode(mode, callback, {retain = false, onChange} = {}) {
         this.disableDrawingMode()
         const drawing = this.getDrawing()
         // Editing an existing shape finishes too, as an 'edit' or 'deleteCoordinate'.
         this.drawingListener = id => {
+            this.clearPolygonPreview()
             const feature = drawing.getSnapshotFeature(id)
             if (retain) {
                 this.retainOnly(drawing, feature)
@@ -230,6 +262,25 @@ export class SepalMap {
             }
         }
         drawing.on('finish', this.drawingListener)
+        if (onChange) {
+            this.drawingChangeListener = (ids, type, context) => {
+                if (this.drawingChangesSuppressed || context?.origin === 'api') {
+                    return
+                }
+                const feature = ids
+                    .map(id => drawing.getSnapshotFeature(id))
+                    .find(feature => feature?.geometry.type === 'Polygon' && feature.properties.mode === mode)
+                if (feature) {
+                    this.clearPolygonPreview()
+                    this.drawingFeatureId = feature.id
+                    onChange(feature)
+                } else if (type === 'delete' && ids.includes(this.drawingFeatureId)) {
+                    this.drawingFeatureId = null
+                    onChange(null)
+                }
+            }
+            drawing.on('change', this.drawingChangeListener)
+        }
         if (!drawing.enabled) {
             drawing.start()
         }
@@ -237,12 +288,18 @@ export class SepalMap {
     }
 
     disableDrawingMode() {
-        const {drawing, drawingListener} = this
+        const {drawing, drawingListener, drawingChangeListener} = this
+        this.clearPolygonPreview()
         if (drawing) {
             if (drawingListener) {
                 drawing.off('finish', drawingListener)
                 this.drawingListener = null
             }
+            if (drawingChangeListener) {
+                drawing.off('change', drawingChangeListener)
+                this.drawingChangeListener = null
+            }
+            this.drawingFeatureId = null
             if (drawing.enabled) {
                 drawing.setMode('static')
                 drawing.stop()
@@ -359,9 +416,12 @@ export class SepalMap {
 
     // Polygon
 
-    enablePolygonDrawing(callback, getPath) {
+    enablePolygonDrawing(callback, getPath, onChange) {
         log.debug('enablePolygonDrawing')
-        this.enableDrawingMode('polygon', feature => callback(toPolygonPath(feature)), {retain: true})
+        this.enableDrawingMode('polygon', feature => callback(toPolygonPath(feature)), {
+            retain: true,
+            onChange: onChange && (feature => onChange(feature ? toPolygonPath(feature) : null))
+        })
         const path = getPath && getPath()
         this.setPolygonDrawing(path)
     }

--- a/modules/gui/src/app/home/map/sepalMap.test.js
+++ b/modules/gui/src/app/home/map/sepalMap.test.js
@@ -60,10 +60,150 @@ const createDrawing = () => {
     return {adapter, drawing}
 }
 
-const createSepalMap = drawing =>
-    Object.assign(Object.create(SepalMap.prototype), {drawing, drawingListener: null})
+const createSepalMap = (drawing, properties = {}) =>
+    Object.assign(Object.create(SepalMap.prototype), {
+        drawing,
+        drawingListener: null,
+        drawingChangeListener: null,
+        drawingChangesSuppressed: false,
+        polygonPreview: null,
+        ...properties
+    })
+
+class TestPolygon {
+    constructor(options) {
+        this.options = options
+    }
+
+    setMap(map) {
+        this.map = map
+    }
+
+    setPath(path) {
+        this.path = path
+    }
+}
+
+const pointerEvent = (lng, lat) => ({
+    lng,
+    lat,
+    containerX: lng,
+    containerY: lat,
+    button: 'left',
+    heldKeys: [],
+    isContextMenu: false
+})
 
 describe('polygon drawing', () => {
+    it('reports provisional polygon changes before drawing finishes', () => {
+        const {adapter, drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+        const changes = []
+
+        map.enablePolygonDrawing(() => {}, () => null, path => changes.push(path))
+        adapter.callbacks.onClick(pointerEvent(10, 20))
+        adapter.callbacks.onMouseMove(pointerEvent(30, 20))
+
+        expect(changes.at(-1)).toEqual([[10, 20], [30, 20], [30, 20]])
+    })
+
+    it('reports when a provisional polygon is cancelled', () => {
+        const {adapter, drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+        const changes = []
+
+        map.enablePolygonDrawing(() => {}, () => null, path => changes.push(path))
+        adapter.callbacks.onClick(pointerEvent(10, 20))
+        adapter.callbacks.onMouseMove(pointerEvent(30, 20))
+        adapter.callbacks.onKeyUp({key: 'Escape', heldKeys: [], preventDefault() {}})
+
+        expect(changes.at(-1)).toBeNull()
+    })
+
+    it('reports cancellation instead of the older polygon when replacing a polygon', () => {
+        const initialPath = [[-100, -50], [-50, -50], [-50, 0]]
+        const {adapter, drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+        const changes = []
+
+        map.enablePolygonDrawing(() => {}, () => initialPath, path => changes.push(path))
+        adapter.callbacks.onClick(pointerEvent(50, 20))
+        adapter.callbacks.onMouseMove(pointerEvent(80, 20))
+        adapter.callbacks.onKeyUp({key: 'Escape', heldKeys: [], preventDefault() {}})
+
+        expect(changes.at(-1)).toBeNull()
+    })
+
+    it('does not report polygon changes loaded through the API', () => {
+        const {drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+        const changes = []
+
+        map.enablePolygonDrawing(() => {}, () => null, path => changes.push(path))
+        map.setPolygonDrawing([[10, 20], [30, 20], [30, 40]])
+
+        expect(changes).toEqual([])
+    })
+
+    it('replaces the editable polygon with a provisional preview until the path is committed', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const previewPath = [[11, 21], [31, 21], [31, 41]]
+        const finalPath = [[12, 22], [32, 22], [32, 42]]
+        const {drawing} = createDrawing()
+        const googleMap = {}
+        const map = createSepalMap(drawing, {
+            google: {maps: {Polygon: TestPolygon}},
+            googleMap
+        })
+        map.setPolygonDrawing(initialPath)
+
+        map.setPolygonPreview(previewPath)
+
+        expect(drawing.getSnapshot().filter(({geometry}) => geometry.type === 'Polygon')).toEqual([])
+        expect(map.polygonPreview.path).toEqual([
+            {lng: 11, lat: 21},
+            {lng: 31, lat: 21},
+            {lng: 31, lat: 41}
+        ])
+        expect(map.polygonPreview.map).toBe(googleMap)
+
+        map.setPolygonDrawing(finalPath)
+
+        expect(map.polygonPreview).toBeNull()
+        expect(drawing.getSnapshot()
+            .filter(({geometry}) => geometry.type === 'Polygon')
+            .map(toPolygonPath)
+        ).toEqual([finalPath])
+    })
+
+    it('removes a synchronized preview when the pane becomes the drawing source', () => {
+        const initialPath = [[-100, -50], [-50, -50], [-50, 0]]
+        const previewPath = [[-90, -40], [-40, -40], [-40, 10]]
+        const {adapter, drawing} = createDrawing()
+        const map = createSepalMap(drawing, {
+            google: {maps: {Polygon: TestPolygon}},
+            googleMap: {}
+        })
+        map.enablePolygonDrawing(() => {}, () => initialPath, path => {
+            if (!path) {
+                map.setPolygonDrawing(initialPath)
+            }
+        })
+        map.setPolygonPreview(previewPath)
+
+        adapter.callbacks.onClick(pointerEvent(50, 20))
+        adapter.callbacks.onMouseMove(pointerEvent(80, 20))
+
+        expect(map.polygonPreview).toBeNull()
+
+        adapter.callbacks.onKeyUp({key: 'Escape', heldKeys: [], preventDefault() {}})
+
+        expect(drawing.getSnapshot()
+            .filter(({geometry}) => geometry.type === 'Polygon')
+            .map(toPolygonPath)
+        ).toEqual([initialPath])
+    })
+
     it('replaces its editable polygon when another pane changes it', () => {
         const initialPath = [[10, 20], [30, 20], [30, 40]]
         const updatedPath = [[11, 21], [31, 21], [31, 41]]

--- a/modules/gui/src/app/home/map/sepalMap.test.js
+++ b/modules/gui/src/app/home/map/sepalMap.test.js
@@ -1,0 +1,94 @@
+import {TerraDraw, TerraDrawPolygonMode} from 'terra-draw'
+
+import {toPolygonPath} from './drawing'
+import {SepalMap} from './sepalMap'
+
+class TestAdapter {
+    cursor = 'unset'
+    doubleClickToZoom = true
+
+    getCoordinatePrecision() {
+        return 9
+    }
+
+    project(lng, lat) {
+        return {x: lng, y: lat}
+    }
+
+    unproject(x, y) {
+        return {lng: x, lat: y}
+    }
+
+    setDoubleClickToZoom(enabled) {
+        this.doubleClickToZoom = enabled
+    }
+
+    setCursor(cursor) {
+        this.cursor = cursor
+    }
+
+    register(callbacks) {
+        this.callbacks = callbacks
+    }
+
+    unregister() {
+        this.clear()
+        this.callbacks = null
+    }
+
+    render() {}
+
+    clear() {
+        this.callbacks?.onClear()
+    }
+
+    setDraggability() {}
+
+    getLngLatFromEvent() {
+        return null
+    }
+}
+
+const createDrawing = () => {
+    const adapter = new TestAdapter()
+    const drawing = new TerraDraw({
+        adapter,
+        modes: [new TerraDrawPolygonMode({editable: true, showCoordinatePoints: true})]
+    })
+    drawing.start()
+    drawing.setMode('polygon')
+    return {adapter, drawing}
+}
+
+const createSepalMap = drawing =>
+    Object.assign(Object.create(SepalMap.prototype), {drawing, drawingListener: null})
+
+describe('polygon drawing', () => {
+    it('replaces its editable polygon when another pane changes it', () => {
+        const initialPath = [[10, 20], [30, 20], [30, 40]]
+        const updatedPath = [[11, 21], [31, 21], [31, 41]]
+        const {drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+
+        map.setPolygonDrawing?.(initialPath)
+        map.setPolygonDrawing?.(updatedPath)
+
+        const paths = drawing.getSnapshot()
+            .filter(({geometry}) => geometry.type === 'Polygon')
+            .map(toPolygonPath)
+        expect(paths).toEqual([updatedPath])
+    })
+
+    it('restores map interactions when drawing is disabled', () => {
+        const {adapter, drawing} = createDrawing()
+        const map = createSepalMap(drawing)
+        expect(adapter.cursor).toBe('crosshair')
+        expect(adapter.doubleClickToZoom).toBe(false)
+
+        map.disableDrawingMode()
+
+        expect(drawing.enabled).toBe(false)
+        expect(adapter.cursor).toBe('unset')
+        expect(adapter.doubleClickToZoom).toBe(true)
+    })
+})


### PR DESCRIPTION
This follow-up to #405 fixes polygon editing and keeps provisional geometry synchronized across ready map panes. It delays Terra Draw startup until a new Google map is ready, prevents programmatic feedback loops, and restores committed geometry after cancellation or source-pane removal.

Validated with the full GUI test suite (1,138 tests), lint, and the production build.