### PR TITLE
Added training data sampling controls to the Classification recipe

### DIFF
--- a/lib/js/ee/src/classification/classification.js
+++ b/lib/js/ee/src/classification/classification.js
@@ -8,6 +8,38 @@ import recipeRef from '#sepal/ee/recipeRef'
 
 const NORMALIZE_MAX_PIXELS = 1e6
 
+// Deterministically keeps sampleSize points out of a class's full list,
+// evenly spaced through it rather than a contiguous prefix/random draw - so
+// a re-run (e.g. GUI preview vs. the actual export task) always picks the
+// same subset, and no single region of the input file is favored.
+const evenlySpaced = (points, sampleSize) =>
+    Array.from({length: sampleSize}, (_unused, i) => points[Math.floor(i * points.length / sampleSize)])
+
+// Keeps samplePercentage% of each class.
+const sampleByPercentage = (referenceData, samplePercentage) => {
+    if (!_.isFinite(samplePercentage) || samplePercentage >= 100) {
+        return referenceData
+    }
+    return Object.values(_.groupBy(referenceData, 'class')).flatMap(points =>
+        evenlySpaced(points, Math.round(points.length * samplePercentage / 100))
+    )
+}
+
+// Caps each class at its own configured count - classes without a configured
+// count (undefined in sampleCountByClass) are kept in full.
+const sampleByCountPerClass = (referenceData, sampleCountByClass = {}) =>
+    Object.entries(_.groupBy(referenceData, 'class')).flatMap(([classValue, points]) => {
+        const maxCount = sampleCountByClass[classValue]
+        return _.isFinite(maxCount)
+            ? evenlySpaced(points, Math.min(points.length, maxCount))
+            : points
+    })
+
+const sampleReferenceData = (referenceData, {sampleMode, samplePercentage, sampleCountByClass}) =>
+    sampleMode === 'CUSTOM_NUMBER'
+        ? sampleByCountPerClass(referenceData, sampleCountByClass)
+        : sampleByPercentage(referenceData, samplePercentage)
+
 const classify =
     ({
         model: {
@@ -73,8 +105,8 @@ const classify =
         )
         const referenceData = dataSets
             .filter(({type}) => type !== 'RECIPE')
-            .map(({referenceData}) => referenceData)
-            .flat()
+            .flatMap(({referenceData, sampleMode, samplePercentage, sampleCountByClass}) =>
+                sampleReferenceData(referenceData, {sampleMode, samplePercentage, sampleCountByClass}))
         const toFeature = plot => {
             return ee.Feature(ee.Geometry.Point([plot['x'], plot['y']]), {'class': plot['class']})
         }

--- a/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/classMappingStep.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/classMappingStep.jsx
@@ -11,6 +11,7 @@ import {ButtonGroup} from '~/widget/buttonGroup'
 import {ButtonPopup} from '~/widget/buttonPopup'
 import {Combo} from '~/widget/combo'
 import {CrudItem} from '~/widget/crudItem'
+import {Form} from '~/widget/form'
 import {Icon} from '~/widget/icon'
 import {Input} from '~/widget/input'
 import {Label} from '~/widget/label'
@@ -20,6 +21,7 @@ import {ListItem} from '~/widget/listItem'
 
 import styles from './classStep.module.css'
 import {filterReferenceData$, remapReferenceData$} from './inputData'
+import {SAMPLEABLE_TYPES} from './sampleableTypes'
 
 const mapRecipeToProps = recipe => ({
     legend: selectFrom(recipe, 'model.legend'),
@@ -39,8 +41,95 @@ class _ClassMappingStep extends Component {
                 {this.renderSingleColumnForm()}
                 {this.renderMultipleColumnsForm()}
                 {this.renderOtherFormatForm()}
+                {this.renderTrainingDataRefinement()}
             </Layout>
         )
+    }
+
+    renderTrainingDataRefinement() {
+        const {more, inputs: {type, sampleMode}} = this.props
+        if (!SAMPLEABLE_TYPES.includes(type.value) || !more) {
+            return null
+        }
+        return (
+            <Layout className={styles.trainingDataRefinement}>
+                <Label msg={msg('process.classification.panel.trainingData.classMapping.trainingDataRefinement.title')}/>
+                <Form.Buttons
+                    label={msg('process.classification.panel.trainingData.classMapping.sampleMode.label')}
+                    input={sampleMode}
+                    multiple={false}
+                    options={[
+                        {
+                            value: 'PERCENTAGE',
+                            label: msg('process.classification.panel.trainingData.classMapping.sampleMode.PERCENTAGE.label')
+                        },
+                        {
+                            value: 'CUSTOM_NUMBER',
+                            label: msg('process.classification.panel.trainingData.classMapping.sampleMode.CUSTOM_NUMBER.label')
+                        }
+                    ]}
+                />
+                {sampleMode.value === 'CUSTOM_NUMBER'
+                    ? this.renderSampleCountByClass()
+                    : this.renderSamplePercentage()}
+            </Layout>
+        )
+    }
+
+    renderSamplePercentage() {
+        const {inputs: {samplePercentage}} = this.props
+        return (
+            <Form.Slider
+                label={msg('process.classification.panel.trainingData.classMapping.samplePercentage.label')}
+                tooltip={msg('process.classification.panel.trainingData.classMapping.samplePercentage.tooltip')}
+                input={samplePercentage}
+                minValue={1}
+                maxValue={100}
+                ticks={[1, 25, 50, 75, 100]}
+                range='low'
+                info={percentage =>
+                    msg('process.classification.panel.trainingData.classMapping.samplePercentage.value', {percentage})
+                }
+            />
+        )
+    }
+
+    renderSampleCountByClass() {
+        const {legend, inputs: {sampleCountByClass}} = this.props
+        const countByClass = sampleCountByClass.value || {}
+        return (
+            <Layout spacing='compact'>
+                {legend.entries.map(({id, value, label, color}) =>
+                    <Layout
+                        key={id}
+                        type='horizontal-nowrap'
+                        spacing='compact'
+                        className={styles.sampleCountRow}>
+                        <LegendItem color={color} label={label} value={value}/>
+                        <Layout.Spacer/>
+                        <Input
+                            className={styles.sampleCount}
+                            type='number'
+                            placeholder={msg('process.classification.panel.trainingData.classMapping.sampleCountByClass.placeholder')}
+                            value={countByClass[value] ?? ''}
+                            onChange={e => this.setSampleCountForClass(value, e.target.value)}
+                        />
+                    </Layout>
+                )}
+            </Layout>
+        )
+    }
+
+    setSampleCountForClass(legendValue, rawValue) {
+        const {inputs: {sampleCountByClass}} = this.props
+        const countByClass = {...(sampleCountByClass.value || {})}
+        const count = parseInt(rawValue)
+        if (rawValue === '' || !_.isFinite(count)) {
+            delete countByClass[legendValue]
+        } else {
+            countByClass[legendValue] = count
+        }
+        sampleCountByClass.set(countByClass)
     }
 
     renderSingleColumnForm() {
@@ -137,18 +226,38 @@ class _ClassMappingStep extends Component {
     }
 
     renderCount(legendValue) {
-        const {stream, inputs: {referenceData}} = this.props
+        const {stream, inputs: {referenceData, type, sampleMode, samplePercentage, sampleCountByClass}} = this.props
         const active = stream('UPDATE_REFERENCE_DATA').active
+        const total = referenceData.value ? (referenceData.value.counts[legendValue] || 0) : null
+        const sampled = this.sampledCount(total, legendValue, {
+            type: type.value,
+            sampleMode: sampleMode.value,
+            samplePercentage: samplePercentage.value,
+            sampleCountByClass: sampleCountByClass.value
+        })
         return (
             <div className={styles.count}>
                 {active
                     ? <Icon name='spinner'/>
-                    : referenceData.value ?
-                        (referenceData.value.counts[legendValue] || 0)
+                    : total !== null
+                        ? (sampled !== null ? `${sampled} / ${total}` : total)
                         : null
                 }
             </div>
         )
+    }
+
+    sampledCount(total, legendValue, {type, sampleMode, samplePercentage, sampleCountByClass}) {
+        if (total === null || !SAMPLEABLE_TYPES.includes(type)) {
+            return null
+        }
+        if (sampleMode === 'CUSTOM_NUMBER') {
+            const maxCount = (sampleCountByClass || {})[legendValue]
+            return _.isFinite(maxCount) ? Math.min(total, maxCount) : null
+        }
+        return _.isFinite(samplePercentage) && samplePercentage < 100
+            ? Math.round(total * samplePercentage / 100)
+            : null
     }
 
     renderMapping(mappingType, legendValue) {
@@ -396,5 +505,6 @@ export const ClassMappingStep = compose(
 
 ClassMappingStep.propTypes = {
     children: PropTypes.any,
-    inputs: PropTypes.any
+    inputs: PropTypes.any,
+    more: PropTypes.bool
 }

--- a/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/classStep.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/classStep.module.css
@@ -66,3 +66,17 @@
     display: flex;
     flex-direction: row;
 }
+
+.trainingDataRefinement {
+    padding: 1rem;
+    border: var(--wireframe);
+    border-radius: .3rem;
+}
+
+.sampleCountRow {
+    align-items: center;
+}
+
+.sampleCount {
+    width: 5rem;
+}

--- a/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/sampleableTypes.js
+++ b/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/sampleableTypes.js
@@ -1,0 +1,5 @@
+// Only bulk/external sources are worth subsetting - manually COLLECTED points
+// are usually few and deliberately placed, RECIPE reuses another recipe's
+// training data as-is, and SAMPLE_CLASSIFICATION already has its own
+// samplesPerClass control at generation time.
+export const SAMPLEABLE_TYPES = ['CSV_UPLOAD', 'EE_TABLE', 'CEO']

--- a/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/trainingDataSet.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/trainingDataSet.jsx
@@ -5,6 +5,7 @@ import {RecipeFormPanel, recipeFormPanel} from '~/app/home/body/process/recipeFo
 import {compose} from '~/compose'
 import {selectFrom} from '~/stateUtils'
 import {msg} from '~/translate'
+import {Button} from '~/widget/button'
 import {Form} from '~/widget/form'
 import {PanelSections} from '~/widget/panelSections'
 
@@ -15,6 +16,7 @@ import {CsvUploadSection} from './csvUploadSection'
 import {EETableSection} from './eeTableSection'
 import {LocationStep} from './locationStep'
 import {RecipeSection} from './recipeSection'
+import {SAMPLEABLE_TYPES} from './sampleableTypes'
 import {SampleClassificationSection} from './sampleClassificationSection'
 import {SectionSelection} from './sectionSelection'
 import styles from './trainingDataSet.module.css'
@@ -100,6 +102,18 @@ const fields = {
     referenceData: new Form.Field()
         .skip((value, {wizardStep}) => wizardStep !== 3)
         .notEmpty('process.classification.panel.trainingData.form.referenceData.required'),
+    sampleMode: new Form.Field()
+        .skip((value, {wizardStep}) => wizardStep !== 3)
+        .skip((value, {type}) => !SAMPLEABLE_TYPES.includes(type)),
+    // Not form-validated (unlike most other fields here) - the EE pipeline
+    // already treats a missing/out-of-range value as "no reduction", so a
+    // strict validator here would only ever risk blocking Done for no
+    // functional reason. The slider widget's own minValue/maxValue already
+    // keeps user-entered values sane in the UI.
+    samplePercentage: new Form.Field(),
+    sampleCountByClass: new Form.Field()
+        .skip((value, {wizardStep}) => wizardStep !== 3)
+        .skip((value, {type}) => !SAMPLEABLE_TYPES.includes(type)),
 }
 
 const mapRecipeToProps = recipe => ({
@@ -107,6 +121,8 @@ const mapRecipeToProps = recipe => ({
 })
 
 class _TrainingDataSet extends React.Component {
+    state = {more: false}
+
     render() {
         const {dataCollectionManager, inputs} = this.props
 
@@ -122,8 +138,27 @@ class _TrainingDataSet extends React.Component {
                     step={inputs.wizardStep}
                     icon='table'
                     label={msg('process.classification.panel.trainingData.sectionSelection.title')}
+                    extraButtons={this.renderExtraButtons()}
                 />
             </RecipeFormPanel>
+        )
+    }
+
+    showMoreButton() {
+        const {inputs: {type, wizardStep}} = this.props
+        return SAMPLEABLE_TYPES.includes(type.value) && wizardStep.value === 3
+    }
+
+    renderExtraButtons() {
+        if (!this.showMoreButton()) {
+            return null
+        }
+        const {more} = this.state
+        return (
+            <Button
+                label={more ? msg('button.less') : msg('button.more')}
+                onClick={() => this.setState(({more}) => ({more: !more}))}
+            />
         )
     }
 
@@ -142,7 +177,10 @@ class _TrainingDataSet extends React.Component {
                     <CsvUploadSection {...this.props}/>,
                     <LocationStep {...this.props}/>,
                     <ClassStep {...this.props}/>,
-                    <ClassMappingStep {...this.props}/>
+                    <ClassMappingStep
+                        {...this.props}
+                        more={this.state.more}
+                    />
                 ]
             },
             {
@@ -154,7 +192,10 @@ class _TrainingDataSet extends React.Component {
                     <EETableSection {...this.props}/>,
                     <LocationStep {...this.props}/>,
                     <ClassStep {...this.props}/>,
-                    <ClassMappingStep {...this.props}/>
+                    <ClassMappingStep
+                        {...this.props}
+                        more={this.state.more}
+                    />
                 ]
             },
             {
@@ -166,7 +207,10 @@ class _TrainingDataSet extends React.Component {
                     <SampleClassificationSection {...this.props}/>,
                     <LocationStep {...this.props}/>,
                     <ClassStep {...this.props}/>,
-                    <ClassMappingStep {...this.props}/>
+                    <ClassMappingStep
+                        {...this.props}
+                        more={this.state.more}
+                    />
                 ]
             },
             {
@@ -185,7 +229,10 @@ class _TrainingDataSet extends React.Component {
                     <CeoSection {...this.props}/>,
                     <LocationStep {...this.props}/>,
                     <ClassStep {...this.props}/>,
-                    <ClassMappingStep {...this.props}/>
+                    <ClassMappingStep
+                        {...this.props}
+                        more={this.state.more}
+                    />
 
                 ]
             }
@@ -254,6 +301,14 @@ const modelToValues = model => {
         columnMapping: model.columnMapping,
         customMapping: model.customMapping,
         defaultValue: model.defaultValue,
+        // Defaulted here (rather than relying on ClassMappingStep's
+        // componentDidMount) so samplePercentage's validators are satisfied
+        // from the form's very first render, with no dependency on a child
+        // component's mount timing - it was otherwise possible for Done to
+        // stay disabled until something forced a re-render after mount.
+        sampleMode: model.sampleMode || 'PERCENTAGE',
+        samplePercentage: model.samplePercentage ?? 100,
+        sampleCountByClass: model.sampleCountByClass || {},
 
         institution: model.institution,
         project: model.project,

--- a/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/trainingDataSet.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/classification/panels/trainingData/trainingDataSet.module.css
@@ -1,4 +1,4 @@
 .panel {
-    height: 40rem;
+    min-height: 40rem;
     width: 40rem;
 }

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -2305,7 +2305,27 @@
             "columnValues": "Column value(s)",
             "enterExpression": "Enter expression",
             "noColumValuesSelected": "No column value selected for this class",
-            "removeColumnValue": "Remove column value"
+            "removeColumnValue": "Remove column value",
+            "trainingDataRefinement": {
+              "title": "Training Data Refinement"
+            },
+            "sampleMode": {
+              "label": "Reduction method",
+              "PERCENTAGE": {
+                "label": "Percentage"
+              },
+              "CUSTOM_NUMBER": {
+                "label": "Custom number"
+              }
+            },
+            "samplePercentage": {
+              "label": "Sample %",
+              "tooltip": "Use only a percentage of the loaded points for each class, rather than all of them. The full set is kept, so this can be adjusted at any time without re-uploading.",
+              "value": "Use {percentage}% of the points in each class"
+            },
+            "sampleCountByClass": {
+              "placeholder": "All"
+            }
           },
           "clearCollected": {
             "confirmation": {

--- a/modules/gui/src/widget/panelSections.jsx
+++ b/modules/gui/src/widget/panelSections.jsx
@@ -54,7 +54,7 @@ class _PanelSections extends React.Component {
     }
 
     renderButtons() {
-        const {step, defaultButtons} = this.props
+        const {step, defaultButtons, extraButtons} = this.props
         const section = this.findSection()
         if (!section.steps) {
             return section.buttons || defaultButtons
@@ -69,14 +69,16 @@ class _PanelSections extends React.Component {
                     last={last}
                     closable
                     onBack={() => step.set(step.value - 1)}
-                    onNext={() => step.set(step.value + 1)}
-                />
+                    onNext={() => step.set(step.value + 1)}>
+                    {extraButtons}
+                </Form.PanelButtons>
             )
         }
     }
 
     shouldComponentUpdate(nextProps) {
         return nextProps.inputs !== this.props.inputs
+            || nextProps.extraButtons !== this.props.extraButtons
     }
 
     componentDidMount() {
@@ -123,6 +125,7 @@ PanelSections.propTypes = {
     sections: PropTypes.array.isRequired,
     selected: PropTypes.any.isRequired, // input field
     defaultButtons: PropTypes.any,
+    extraButtons: PropTypes.any, // rendered bottom-left, inline with Back/Next/Done
     icon: PropTypes.string,
     label: PropTypes.string,
     shared: PropTypes.array,


### PR DESCRIPTION
Split out of #401 (commit by @eriklindquist) so the two features can be reviewed independently.

Adds training-data refinement to the Classification recipe: CSV/EE Table/CEO-sourced data sets can be reduced before training via a "More" toggle revealing a "Training Data Refinement" section with two modes — keep a percentage of each class's points, or cap each legend class at its own point count. Selection is deterministic and evenly spaced per class, so the GUI's count preview matches what the classifier trains on. The full point set is kept in the model, so the reduction is adjustable without re-uploading, and old datasets are unaffected.

Also adds a backward-compatible `extraButtons` prop to the shared PanelSections widget for the footer toggle, and fixes a `shouldComponentUpdate` gap that dropped prop-driven updates unrelated to the inputs reference.
