### PR TITLE
Resolved app tagline and description translations from the catalog

### DIFF
--- a/modules/gui/src/app/home/body/apps/appList/appList.jsx
+++ b/modules/gui/src/app/home/body/apps/appList/appList.jsx
@@ -10,7 +10,7 @@ import {compose} from '~/compose'
 import {connect} from '~/connect'
 import {select} from '~/store'
 import {simplifyString, splitString} from '~/string'
-import {getLanguage, msg} from '~/translate'
+import {msg} from '~/translate'
 import {isServiceAccount} from '~/user'
 import {currentUser} from '~/user'
 import {Button} from '~/widget/button'
@@ -198,9 +198,7 @@ class _AppList extends React.Component {
     renderTagFilter(tags) {
         const {tagFilter} = this.props
         const toOption = ({label, value, icon, tooltip}) => ({
-            label: label[getLanguage()]
-                || label['en']
-                || Object.values(label)[0],
+            label,
             value,
             ...(icon ? {icon} : {}),
             ...(tooltip ? {tooltip} : {})

--- a/modules/gui/src/apps.js
+++ b/modules/gui/src/apps.js
@@ -5,13 +5,14 @@ import {actionBuilder} from '~/action-builder'
 import api from '~/apiRegistry'
 import {normalizeAppsCatalog} from '~/appsCatalog'
 import {select} from '~/store'
+import {getLanguage} from '~/translate'
 
 export const appList = () =>
     select('apps.list') || []
 
 export const loadApps$ = () =>
     api.apps.loadAll$().pipe(
-        map(rawSpec => normalizeAppsCatalog(rawSpec)),
+        map(rawSpec => normalizeAppsCatalog(rawSpec, getLanguage())),
         map(appsSpec => actionBuilder('SET_APPS')
             .set('apps.list', _.orderBy(appsSpec.apps, ['pinned', 'label'], ['desc', 'asc']))
             .set('apps.tags', _.orderBy(appsSpec.tags, ['label'], ['asc']))

--- a/modules/gui/src/appsCatalog.js
+++ b/modules/gui/src/appsCatalog.js
@@ -25,12 +25,29 @@ const mergeTags = (parentTags, childTags) => {
     return out
 }
 
+const LOCALIZED_FIELDS = ['tagline', 'description']
+
+// `translations[lang]` overrides the English field-by-field; anything missing
+// falls through to the flat English value.
+const localizeApp = (app, language) => {
+    const translation = app.translations?.[language]
+    if (!translation) return app
+    const localized = {...app}
+    for (const field of LOCALIZED_FIELDS) {
+        if (translation[field] !== undefined) {
+            localized[field] = translation[field]
+        }
+    }
+    return localized
+}
+
 // A child declaring either logo key owns both of them, so a parent `logo` can
 // never win over a logo the child chose to express as a `logoRef`.
 const logoOwner = (parent, child) =>
     child.logo !== undefined || child.logoRef !== undefined ? child : parent
 
-const flattenChild = (parent, child) => {
+const flattenChild = (parent, rawChild, language) => {
+    const child = localizeApp(rawChild, language)
     const route = child.route !== undefined ? child.route : child.id
     const path = child.path || joinPath(parent.path, route)
     const logo = logoOwner(parent, child)
@@ -57,7 +74,16 @@ const flattenChild = (parent, child) => {
     }
 }
 
-export const normalizeAppsCatalog = appsSpec => {
+// Tag labels are `{lang: text}` objects in the catalog; pick the language
+// once here so the store holds plain strings that sort and render directly.
+const localizeTag = ({label, ...tag}, language) => ({
+    ...tag,
+    label: typeof label === 'string'
+        ? label
+        : label[language] || label.en || Object.values(label)[0]
+})
+
+export const normalizeAppsCatalog = (appsSpec, language) => {
     const out = []
     for (const entry of appsSpec.apps || []) {
         if (Array.isArray(entry.apps)) {
@@ -67,13 +93,17 @@ export const normalizeAppsCatalog = appsSpec => {
             // unaffected.
             out.push({...parent, hidden: true})
             for (const child of children) {
-                out.push(flattenChild(parent, child))
+                out.push(flattenChild(parent, child, language))
             }
         } else {
-            out.push(entry)
+            out.push(localizeApp(entry, language))
         }
     }
-    return {...appsSpec, apps: out}
+    return {
+        ...appsSpec,
+        apps: out,
+        ...(appsSpec.tags ? {tags: appsSpec.tags.map(tag => localizeTag(tag, language))} : {})
+    }
 }
 
 const isAbsoluteHttpsUrl = value => /^https:\/\//i.test(value)

--- a/modules/gui/src/appsCatalog.test.js
+++ b/modules/gui/src/appsCatalog.test.js
@@ -189,3 +189,75 @@ describe('fallbackLogoUrl', () => {
         expect(fallbackLogoUrl({logoRef: 'sepal.png'})).toBeNull()
     })
 })
+
+describe('normalizeAppsCatalog localization', () => {
+    it('resolves tagline and description from translations for the given language', () => {
+        const input = {
+            apps: [{
+                id: 'alerts',
+                label: 'Alerts',
+                tagline: 'Track alerts',
+                description: 'Long **text**',
+                translations: {
+                    es: {tagline: 'Seguir alertas', description: 'Texto **largo**'}
+                }
+            }]
+        }
+        const [app] = normalizeAppsCatalog(input, 'es').apps
+        expect(app.tagline).toBe('Seguir alertas')
+        expect(app.description).toBe('Texto **largo**')
+    })
+
+    it('falls back to the English field when the translation lacks it', () => {
+        const input = {
+            apps: [{
+                id: 'alerts',
+                tagline: 'Track alerts',
+                description: 'Long text',
+                translations: {es: {tagline: 'Seguir alertas'}}
+            }]
+        }
+        const [app] = normalizeAppsCatalog(input, 'es').apps
+        expect(app.tagline).toBe('Seguir alertas')
+        expect(app.description).toBe('Long text')
+    })
+
+    it('resolves bundle child translations before the child label fallback', () => {
+        const input = {
+            apps: [{
+                id: 'bundle',
+                endpoint: 'docker',
+                path: '/api/app-launcher/bundle',
+                apps: [
+                    {id: 'gfc', label: 'GFC', description: 'Forest change', translations: {es: {tagline: 'Cambio forestal', description: 'Cambio de bosque'}}},
+                    {id: 'fcdm', label: 'FCDM', translations: {fr: {tagline: 'Détection'}}}
+                ]
+            }]
+        }
+        const [, gfc, fcdm] = normalizeAppsCatalog(input, 'es').apps
+        expect(gfc.tagline).toBe('Cambio forestal')
+        expect(gfc.description).toBe('Cambio de bosque')
+        expect(fcdm.tagline).toBe('FCDM')
+        expect(fcdm.description).toBe('')
+    })
+
+    it('flattens tag labels to the given language, falling back to English', () => {
+        const input = {
+            apps: [],
+            tags: [
+                {value: 'TOOLS', label: {en: 'Tools', es: 'Herramientas'}},
+                {value: 'FOREST', label: {en: 'Forest'}}
+            ]
+        }
+        const {tags} = normalizeAppsCatalog(input, 'es')
+        expect(tags).toEqual([
+            {value: 'TOOLS', label: 'Herramientas'},
+            {value: 'FOREST', label: 'Forest'}
+        ])
+    })
+
+    it('passes plain-string tag labels through unchanged', () => {
+        const input = {apps: [], tags: [{value: 'TOOLS', label: 'Tools'}]}
+        expect(normalizeAppsCatalog(input, 'es').tags).toEqual([{value: 'TOOLS', label: 'Tools'}])
+    })
+})


### PR DESCRIPTION
Part of #100. The apps catalog is getting a per-app `translations` block (`{es: {tagline, description}, fr: {...}}`, see dfguerrerom/sepal-apps-catalog#74). This makes the GUI resolve it: `normalizeAppsCatalog` now takes the current language and overrides `tagline`/`description` from `translations[language]` field by field, falling back to the English values, for top-level apps and multiapp bundle children alike.

Tag labels (`{en, es, ...}` objects) are flattened to a string in the same place, so the tag filter no longer resolves them itself and the `apps.tags` sort by label works.

No app-manager/app-launcher changes; catalogs without `translations` behave as before.