### PR TITLE
Added a mosaics visualization mode to LandTrendr.

### DIFF
--- a/lib/js/ee/src/timeSeries/landTrendr.js
+++ b/lib/js/ee/src/timeSeries/landTrendr.js
@@ -46,10 +46,13 @@ const compositeOrMasked = (collection, bandNames) => ee.Image(ee.Algorithms.If(
     ee.Image.constant(bandNames.map(() => 0)).rename(bandNames).selfMask()
 ))
 
-// The annual composite the algorithm itself consumed, expressed as a MOSAIC
-// recipe: same calendar-year window, same sources and corrections, MEDIAN
-// compose. Delegating to it means the whole optical band and vis-params
-// catalogue is available for context imagery, rather than a hand-built subset.
+// Context imagery for one year, expressed as a MOSAIC recipe: same scenes,
+// calendar-year window, sources and corrections as the series the algorithm was
+// fitted to. Not that series itself - that is a single direction-flipped index
+// band whose yearly value is the median of the per-scene index, whereas a
+// MOSAIC recipe derives its indexes from the already-composited bands. So the
+// index band here will not match preval/postval exactly. Delegating gets the
+// whole optical band and vis-params catalogue rather than a hand-built subset.
 const toMosaicRecipe = (recipe, year) => ({
     type: 'MOSAIC',
     model: {

--- a/lib/js/ee/src/timeSeries/landTrendr.js
+++ b/lib/js/ee/src/timeSeries/landTrendr.js
@@ -8,6 +8,8 @@ const OUTPUT_BANDS = ['yod', 'mag', 'dur', 'preval', 'postval', 'rmse', 'sig']
 const RGB_BANDS = ['red', 'green', 'blue']
 const START_RGB_BANDS = ['startRed', 'startGreen', 'startBlue']
 const END_RGB_BANDS = ['endRed', 'endGreen', 'endBlue']
+const RGB_OUTPUT_BANDS = [...START_RGB_BANDS, ...END_RGB_BANDS]
+const ALL_BANDS = [...OUTPUT_BANDS, ...RGB_OUTPUT_BANDS]
 
 // -1: index naturally DECREASES with disturbance (e.g. vegetation/moisture
 //     indices), so it's flipped before fitting - a rise in the fitted series
@@ -48,10 +50,12 @@ const compositeOrMasked = (collection, bandNames) => ee.Image(ee.Algorithms.If(
     ee.Image.constant(bandNames.map(() => 0)).rename(bandNames).selfMask()
 ))
 
-const landTrendr = (recipe, _args = {selection: []}) => {
+const landTrendr = (recipe, {selection: selectedBands} = {selection: []}) => {
     const {startYear, endYear} = recipe.model.dates
     const index = recipe.model.sources.index
     const direction = DIRECTION_BY_INDEX[index] ?? 1
+    const outputBands = selectedBands.length ? selectedBands : ALL_BANDS
+    const includeRgb = outputBands.some(band => RGB_OUTPUT_BANDS.includes(band))
 
     const collectionForYear$ = (geometry, year, bands) => {
         const collectionRecipe = {
@@ -228,11 +232,10 @@ const landTrendr = (recipe, _args = {selection: []}) => {
         getImage$: () => toGeometry$(recipe.model.aoi).pipe(
             switchMap(geometry => forkJoin({
                 changeMap: fit$(geometry).pipe(map(ltResult => toChangeMap(ltResult))),
-                rgb: rgbComposites$(geometry)
+                rgb: includeRgb ? rgbComposites$(geometry) : of(null)
             }).pipe(
-                map(({changeMap, rgb}) => changeMap
-                    .addBands(rgb)
-                    .select([...OUTPUT_BANDS, ...START_RGB_BANDS, ...END_RGB_BANDS])
+                map(({changeMap, rgb}) => (rgb ? changeMap.addBands(rgb) : changeMap)
+                    .select(outputBands)
                     .clip(geometry)
                 )
             ))
@@ -252,7 +255,7 @@ const landTrendr = (recipe, _args = {selection: []}) => {
                 })
             ))
         ),
-        getBands$: () => of([...OUTPUT_BANDS, ...START_RGB_BANDS, ...END_RGB_BANDS]),
+        getBands$: () => of(ALL_BANDS),
         getGeometry$: () => toGeometry$(recipe.model.aoi)
     }
 }

--- a/lib/js/ee/src/timeSeries/landTrendr.js
+++ b/lib/js/ee/src/timeSeries/landTrendr.js
@@ -1,15 +1,11 @@
-import {forkJoin, map, of, switchMap} from 'rxjs'
+import {map, of, switchMap} from 'rxjs'
 
 import {toGeometry$} from '#sepal/ee/aoi'
 import ee from '#sepal/ee/ee'
+import imageFactory from '#sepal/ee/imageFactory'
 import {getCollection$} from '#sepal/ee/timeSeries/collection'
 
 const OUTPUT_BANDS = ['yod', 'mag', 'dur', 'preval', 'postval', 'rmse', 'sig']
-const RGB_BANDS = ['red', 'green', 'blue']
-const START_RGB_BANDS = ['startRed', 'startGreen', 'startBlue']
-const END_RGB_BANDS = ['endRed', 'endGreen', 'endBlue']
-const RGB_OUTPUT_BANDS = [...START_RGB_BANDS, ...END_RGB_BANDS]
-const ALL_BANDS = [...OUTPUT_BANDS, ...RGB_OUTPUT_BANDS]
 
 // -1: index naturally DECREASES with disturbance (e.g. vegetation/moisture
 //     indices), so it's flipped before fitting - a rise in the fitted series
@@ -50,25 +46,40 @@ const compositeOrMasked = (collection, bandNames) => ee.Image(ee.Algorithms.If(
     ee.Image.constant(bandNames.map(() => 0)).rename(bandNames).selfMask()
 ))
 
-const landTrendr = (recipe, {selection: selectedBands} = {selection: []}) => {
+// The annual composite the algorithm itself consumed, expressed as a MOSAIC
+// recipe: same calendar-year window, same sources and corrections, MEDIAN
+// compose. Delegating to it means the whole optical band and vis-params
+// catalogue is available for context imagery, rather than a hand-built subset.
+const toMosaicRecipe = (recipe, year) => ({
+    type: 'MOSAIC',
+    model: {
+        aoi: recipe.model.aoi,
+        dates: {
+            targetDate: `${year}-07-01`,
+            seasonStart: `${year}-01-01`,
+            seasonEnd: `${year + 1}-01-01`,
+            yearsBefore: 0,
+            yearsAfter: 0
+        },
+        sources: recipe.model.sources,
+        sceneSelectionOptions: {type: 'ALL'},
+        compositeOptions: {
+            ...recipe.model.options,
+            compose: 'MEDIAN'
+        }
+    }
+})
+
+const landTrendr = (recipe, {selection: selectedBands, visualizationType, year} = {selection: []}) => {
     const {startYear, endYear} = recipe.model.dates
     const index = recipe.model.sources.index
     const direction = DIRECTION_BY_INDEX[index] ?? 1
-    const outputBands = selectedBands.length ? selectedBands : ALL_BANDS
-    const includeRgb = outputBands.some(band => RGB_OUTPUT_BANDS.includes(band))
+    const outputBands = selectedBands.length ? selectedBands : OUTPUT_BANDS
 
-    const collectionForYear$ = (geometry, year, bands) => {
-        const collectionRecipe = {
-            model: {
-                dates: {
-                    startDate: `${year}-01-01`,
-                    endDate: `${year + 1}-01-01`
-                },
-                sources: recipe.model.sources,
-                options: recipe.model.options
-            }
-        }
-        return getCollection$({recipe: collectionRecipe, geometry, bands})
+    // Only the map layer ever asks for mosaics; the retrieval and pixel-chart
+    // paths call in without a visualizationType and take the change path.
+    if (visualizationType === 'mosaics') {
+        return imageFactory(toMosaicRecipe(recipe, year ?? endYear), {selection: selectedBands})
     }
 
     const timeSeries$ = geometry => {
@@ -97,15 +108,6 @@ const landTrendr = (recipe, {selection: selectedBands} = {selection: []}) => {
             ).sort('system:time_start'))
         )
     }
-
-    // The start- and end-year RGB composites, so the "before"/"after" imagery
-    // can be viewed alongside the segmentation summary bands.
-    const rgbComposites$ = geometry => forkJoin({
-        start: collectionForYear$(geometry, startYear, RGB_BANDS).pipe(map(collection => compositeOrMasked(collection, RGB_BANDS))),
-        end: collectionForYear$(geometry, endYear, RGB_BANDS).pipe(map(collection => compositeOrMasked(collection, RGB_BANDS)))
-    }).pipe(
-        map(({start, end}) => start.rename(START_RGB_BANDS).addBands(end.rename(END_RGB_BANDS)))
-    )
 
     // Runs the built-in LandTrendr algorithm. Its 'LandTrendr' output band is
     // a per-pixel array with 4 rows (year, raw value, fitted value, isVertex)
@@ -230,11 +232,8 @@ const landTrendr = (recipe, {selection: selectedBands} = {selection: []}) => {
 
     return {
         getImage$: () => toGeometry$(recipe.model.aoi).pipe(
-            switchMap(geometry => forkJoin({
-                changeMap: fit$(geometry).pipe(map(ltResult => toChangeMap(ltResult))),
-                rgb: includeRgb ? rgbComposites$(geometry) : of(null)
-            }).pipe(
-                map(({changeMap, rgb}) => (rgb ? changeMap.addBands(rgb) : changeMap)
+            switchMap(geometry => fit$(geometry).pipe(
+                map(ltResult => toChangeMap(ltResult)
                     .select(outputBands)
                     .clip(geometry)
                 )
@@ -255,7 +254,7 @@ const landTrendr = (recipe, {selection: selectedBands} = {selection: []}) => {
                 })
             ))
         ),
-        getBands$: () => of(ALL_BANDS),
+        getBands$: () => of(OUTPUT_BANDS),
         getGeometry$: () => toGeometry$(recipe.model.aoi)
     }
 }

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/bands.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/bands.js
@@ -1,29 +1,40 @@
+import {getAvailableBands as opticalBands} from '~/app/home/body/process/recipe/opticalMosaic/bands'
 import {msg} from '~/translate'
+
+import {toMosaicRecipe} from './mosaicRecipe'
 
 const typeInt = {precision: 'int'}
 const typeFloat = {precision: 'float'}
 
-export const getAvailableBands = () => ({
+const changeBands = () => ({
     yod: {dataType: typeInt, label: msg('process.landTrendr.bands.yod')},
     mag: {dataType: typeFloat, label: msg('process.landTrendr.bands.mag')},
     dur: {dataType: typeInt, label: msg('process.landTrendr.bands.dur')},
     preval: {dataType: typeFloat, label: msg('process.landTrendr.bands.preval')},
     postval: {dataType: typeFloat, label: msg('process.landTrendr.bands.postval')},
     rmse: {dataType: typeFloat, label: msg('process.landTrendr.bands.rmse')},
-    sig: {dataType: typeFloat, label: msg('process.landTrendr.bands.sig')},
-    startRed: {dataType: typeInt, label: msg('process.landTrendr.bands.startRed')},
-    startGreen: {dataType: typeInt, label: msg('process.landTrendr.bands.startGreen')},
-    startBlue: {dataType: typeInt, label: msg('process.landTrendr.bands.startBlue')},
-    endRed: {dataType: typeInt, label: msg('process.landTrendr.bands.endRed')},
-    endGreen: {dataType: typeInt, label: msg('process.landTrendr.bands.endGreen')},
-    endBlue: {dataType: typeInt, label: msg('process.landTrendr.bands.endBlue')}
+    sig: {dataType: typeFloat, label: msg('process.landTrendr.bands.sig')}
 })
 
+const mosaicBands = recipe => opticalBands(toMosaicRecipe(recipe))
+
+// Without a visualizationType the caller is asking what the layer might show at
+// all - recipeImageLayer does this to build its dataTypes lookup - so it needs
+// both modes, not whichever one happens to be the default.
+export const getAvailableBands = (recipe, visualizationType) => {
+    switch (visualizationType) {
+        case 'changes': return changeBands()
+        case 'mosaics': return mosaicBands(recipe)
+        default: return {...changeBands(), ...mosaicBands(recipe)}
+    }
+}
+
+// Mosaic bands are deliberately absent: they're plain annual composites,
+// unrelated to the per-pixel change segment the change bands describe, and an
+// Optical Mosaic recipe is the right way to export that imagery.
 export const getGroupedBandOptions = () => {
-    const availableBands = getAvailableBands()
+    const availableBands = changeBands()
     return [
-        ['yod', 'mag', 'dur', 'preval', 'postval', 'rmse', 'sig'],
-        ['startRed', 'startGreen', 'startBlue'],
-        ['endRed', 'endGreen', 'endBlue']
-    ].map(bands => bands.map(band => ({value: band, ...availableBands[band]})))
+        Object.keys(availableBands).map(band => ({value: band, ...availableBands[band]}))
+    ]
 }

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/bands.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/bands.test.js
@@ -1,0 +1,42 @@
+import {vi} from 'vitest'
+
+vi.mock('~/translate', () => ({msg: id => id}))
+
+const {getAvailableBands, getGroupedBandOptions} = await import('./bands')
+
+const CHANGE_BANDS = ['yod', 'mag', 'dur', 'preval', 'postval', 'rmse', 'sig']
+
+const recipe = {
+    model: {
+        dates: {startYear: 2000, endYear: 2024},
+        sources: {dataSets: {LANDSAT: ['LANDSAT_8']}},
+        options: {corrections: ['SR']}
+    }
+}
+
+it('exposes only the change bands in changes mode', () => {
+    expect(Object.keys(getAvailableBands(recipe, 'changes'))).toEqual(CHANGE_BANDS)
+})
+
+it('exposes the optical mosaic bands in mosaics mode', () => {
+    const bands = Object.keys(getAvailableBands(recipe, 'mosaics'))
+    expect(bands).toContain('ndvi')
+    expect(bands).toContain('red')
+})
+
+it('exposes both sets when no visualization type is given', () => {
+    const bands = Object.keys(getAvailableBands(recipe))
+    expect(bands).toContain('yod')
+    expect(bands).toContain('ndvi')
+})
+
+it('no longer exposes the start and end RGB composites', () => {
+    const bands = Object.keys(getAvailableBands(recipe))
+    expect(bands).not.toContain('startRed')
+    expect(bands).not.toContain('endBlue')
+})
+
+it('offers only the change bands for retrieval', () => {
+    const bands = getGroupedBandOptions().flat().map(({value}) => value)
+    expect(bands).toEqual(CHANGE_BANDS)
+})

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/landTrendrImageLayer.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/landTrendrImageLayer.jsx
@@ -1,60 +1,173 @@
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import {VisualizationSelector} from '~/app/home/map/imageLayerSource/visualizationSelector'
+import {withMapArea} from '~/app/home/map/mapAreaContext'
 import {MapAreaLayout} from '~/app/home/map/mapAreaLayout'
+import {asFunctionalComponent} from '~/classComponent'
 import {compose} from '~/compose'
+import {selectFrom} from '~/stateUtils'
 import {msg} from '~/translate'
+import {Buttons} from '~/widget/buttons'
+import {Combo} from '~/widget/combo'
+import {Layout} from '~/widget/layout'
 
+import {withRecipe} from '../../recipeContext'
 import {getAvailableBands} from './bands'
-import {getPreSetVisualizations} from './visualizations'
+import {visualizationOptions} from './visualizations'
 
-const combinedLabels = () => ({
-    'startRed,startGreen,startBlue': msg('process.landTrendr.bands.startRgb'),
-    'endRed,endGreen,endBlue': msg('process.landTrendr.bands.endRgb')
+const defaultLayerConfig = {visualizationType: 'changes'}
+
+const mapRecipeToProps = (recipe, {source}) => ({
+    initialized: selectFrom(recipe, 'ui.initialized'),
+    dates: selectFrom(recipe, 'model.dates'),
+    userDefinedVisualizations: selectFrom(recipe, ['layers.userDefinedVisualizations', source.id]) || []
 })
 
 class _LandTrendrImageLayer extends React.Component {
     render() {
-        const {layer, map} = this.props
+        const {initialized, layer, map} = this.props
+        return initialized
+            ? (
+                <MapAreaLayout
+                    layer={layer}
+                    form={this.renderImageLayerForm()}
+                    map={map}
+                />
+            )
+            : null
+    }
+
+    renderImageLayerForm() {
+        const {layerConfig: {visualizationType}} = this.props
         return (
-            <MapAreaLayout
-                layer={layer}
-                form={this.renderImageLayerForm()}
-                map={map}
+            <Layout>
+                {this.renderVisualizationType()}
+                {visualizationType === 'mosaics' ? this.renderYear() : null}
+                {this.renderVisualizationSelector()}
+            </Layout>
+        )
+    }
+
+    renderVisualizationType() {
+        const {layerConfig: {visualizationType}} = this.props
+        const options = [
+            {value: 'changes', label: msg('process.landTrendr.imageLayerForm.visualizationType.changes.label'), tooltip: msg('process.landTrendr.imageLayerForm.visualizationType.changes.tooltip')},
+            {value: 'mosaics', label: msg('process.landTrendr.imageLayerForm.visualizationType.mosaics.label'), tooltip: msg('process.landTrendr.imageLayerForm.visualizationType.mosaics.tooltip')}
+        ]
+        const selectedOption = options.find(({value}) => value === visualizationType) || {}
+        return (
+            <Buttons
+                label={msg('process.landTrendr.imageLayerForm.visualizationType.label')}
+                selected={selectedOption.value}
+                options={options}
+                onChange={visualizationType => this.selectVisualizationType(visualizationType)}
             />
         )
     }
 
-    renderImageLayerForm() {
+    renderYear() {
+        const {dates: {startYear, endYear}, layerConfig: {year}} = this.props
+        const options = _.range(startYear, endYear + 1)
+            .map(year => ({value: year, label: `${year}`}))
+        return (
+            <Combo
+                label={msg('process.landTrendr.imageLayerForm.year.label')}
+                tooltip={msg('process.landTrendr.imageLayerForm.year.tooltip')}
+                placeholder={msg('process.landTrendr.imageLayerForm.year.label')}
+                options={options}
+                value={year}
+                onChange={({value}) => this.selectYear(value)}
+            />
+        )
+    }
+
+    renderVisualizationSelector() {
         const {recipe, source, layerConfig = {}} = this.props
-        const availableBands = getAvailableBands()
-        const rgbLabels = combinedLabels()
-        const preSetOptions = getPreSetVisualizations(recipe)
-            .map(visParams => {
-                const key = visParams.bands.join(',')
-                const label = visParams.bands.length === 1
-                    ? availableBands[visParams.bands[0]].label
-                    : rgbLabels[key] || key
-                return {value: key, label, visParams}
-            })
-        const options = [{
-            label: msg('process.landTrendr.layers.imageLayer.preSets'),
-            options: preSetOptions
-        }]
+        const {visualizationType} = layerConfig
         return (
             <VisualizationSelector
                 source={source}
                 recipe={recipe}
-                presetOptions={options}
+                presetOptions={visualizationOptions(recipe, visualizationType)}
+                availableBands={Object.keys(getAvailableBands(recipe, visualizationType))}
                 selectedVisParams={layerConfig.visParams}
             />
         )
     }
+
+    componentDidMount() {
+        const {layerConfig: {visParams, visualizationType}, dates: {endYear}, mapArea: {updateLayerConfig}} = this.props
+        if (!visualizationType) {
+            updateLayerConfig({...defaultLayerConfig, year: endYear})
+        }
+        this.update(visParams)
+    }
+
+    componentDidUpdate(prevProps) {
+        const {layerConfig: {visParams: prevVisParams}} = prevProps
+        this.update(prevVisParams)
+    }
+
+    // Switching mode changes which bands exist, so a visParams selected for the
+    // previous mode has to be replaced rather than left dangling.
+    update(prevVisParams) {
+        const {recipe} = this.props
+        if (!recipe) return
+        const allVisualizations = this.toAllVis()
+        if (!allVisualizations.length) return
+        if (prevVisParams) {
+            const visParams = allVisualizations
+                .find(({id, bands}) => id === prevVisParams.id && (prevVisParams.id || _.isEqual(bands, prevVisParams.bands)))
+            if (!visParams) {
+                this.selectVisualization(allVisualizations[0])
+            } else if (!_.isEqual(visParams, prevVisParams)) {
+                this.selectVisualization(visParams)
+            }
+        } else {
+            this.selectVisualization(allVisualizations[0])
+        }
+    }
+
+    toAllVis() {
+        const {userDefinedVisualizations, layerConfig: {visualizationType}, recipe} = this.props
+        const availableBands = getAvailableBands(recipe, visualizationType)
+        const flatten = options => options
+            .map(option => option.options
+                ? flatten(option.options)
+                : option.visParams
+            )
+            .flat()
+        return [
+            ...userDefinedVisualizations,
+            ...flatten(visualizationOptions(recipe, visualizationType))
+        ].filter(visParams => visParams.bands.every(band => Object.keys(availableBands).includes(band)))
+    }
+
+    selectVisualization(visParams) {
+        const {layerConfig, mapArea: {updateLayerConfig}} = this.props
+        updateLayerConfig({...layerConfig, visParams})
+    }
+
+    selectVisualizationType(visualizationType) {
+        const {dates: {endYear}, layerConfig: {year}, mapArea: {updateLayerConfig}} = this.props
+        updateLayerConfig({visualizationType, year: year ?? endYear})
+    }
+
+    selectYear(year) {
+        const {layerConfig: {visualizationType}, mapArea: {updateLayerConfig}} = this.props
+        updateLayerConfig({visualizationType, year})
+    }
 }
 
 export const LandTrendrImageLayer = compose(
-    _LandTrendrImageLayer
+    _LandTrendrImageLayer,
+    withMapArea(),
+    withRecipe(mapRecipeToProps),
+    asFunctionalComponent({
+        layerConfig: defaultLayerConfig
+    })
 )
 
 LandTrendrImageLayer.propTypes = {

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/landTrendrRecipe.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/landTrendrRecipe.js
@@ -8,8 +8,8 @@ import {submitRetrieveRecipeTask as submitTask} from '~/app/home/body/process/re
 // yod/dur are whole years, not continuous values - averaging them at
 // overview zoom levels (e.g. yod 2003 and 2004 -> 2003.5) is meaningless,
 // so they need 'sample' pyramiding like changeAlerts/baytsAlerts use for
-// their own discrete bands. The rest (mag/preval/postval and the RGB
-// composites) are genuinely continuous and read better with 'mean'.
+// their own discrete bands. The rest (mag/preval/postval/rmse/sig) are
+// genuinely continuous and read better with 'mean'.
 const SAMPLE_BANDS = ['yod', 'dur']
 const pyramidingPolicy = bands => {
     const policy = {}

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/mosaicRecipe.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/mosaicRecipe.js
@@ -1,0 +1,21 @@
+import {selectFrom} from '~/stateUtils'
+
+// Just enough of a MOSAIC recipe for the optical band and visualization
+// helpers, which only read model.sources.dataSets and model.compositeOptions -
+// hence no type, aoi, dates or scene selection here.
+//
+// The mosaic that actually gets rendered is built by toMosaicRecipe() in
+// lib/js/ee/src/timeSeries/landTrendr.js. Keep `compose` and the corrections
+// in step with it: opticalBands() drops the metadata bands only when compose
+// is MEDIAN, so if the two drift apart this offers bands the image lacks.
+export const toMosaicRecipe = recipe => ({
+    model: {
+        sources: {
+            dataSets: selectFrom(recipe, 'model.sources.dataSets') || {}
+        },
+        compositeOptions: {
+            ...selectFrom(recipe, 'model.options'),
+            compose: 'MEDIAN'
+        }
+    }
+})

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/chartPixel.module.css
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/chartPixel.module.css
@@ -3,7 +3,6 @@
 
 .form {
     height: 23rem;
-    border-top: var(--wireframe);
 }
 
 @media screen and (max-height: 500px) {

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.jsx
@@ -102,13 +102,13 @@ export class LandTrendrGraph extends React.Component {
     }
 
     highlightCallback(event, x, points, row) {
-        const {years, raw, fitted, isVertex} = this.props
+        const {years, raw, fitted} = this.props
         const point = points[0]
         this.setState({
             point: {
                 year: years[row],
                 raw: raw[row],
-                fitted: isVertex[row] ? fitted[row] : null,
+                fitted: fitted[row],
                 left: point.x <= 0.5
             }
         })
@@ -136,15 +136,18 @@ export class LandTrendrGraph extends React.Component {
         }
     }
 
+    // LandTrendr fits a value for every year of the series - the vertices are
+    // only where the trajectory changes slope, so plotting vertices alone drew
+    // the same line but left the hovered year with nothing to report.
     calculateData() {
-        const {years, raw, fitted, isVertex} = this.props
+        const {years, raw, fitted} = this.props
         if (!years || !years.length) {
             return null
         }
         return years.map((year, i) => [
             new Date(year, 6, 1),
-            [raw[i], 0],
-            isVertex[i] ? [fitted[i], 0] : null
+            _.isFinite(raw[i]) ? [raw[i], 0] : null,
+            _.isFinite(fitted[i]) ? [fitted[i], 0] : null
         ])
     }
 }

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.jsx
@@ -13,17 +13,23 @@ import styles from './landTrendrGraph.module.css'
 export class LandTrendrGraph extends React.Component {
     state = {}
 
+    constructor(props) {
+        super(props)
+        this.highlightCallback = this.highlightCallback.bind(this)
+    }
+
     render() {
-        const {years} = this.props
-        if (!years || !years.length) {
+        const {data} = this.state
+        if (!data) {
             return null
         }
         const unhighlightCallback = () => this.setState({point: null})
         return (
             <div className={styles.wrapper}>
                 <Graph
-                    data={this.calculateData()}
+                    data={data}
                     connectSeparatedPoints
+                    showLabelsOnHighlight={false}
                     labels={['dates', 'observations', 'segments']}
                     series={{
                         segments: {
@@ -39,6 +45,8 @@ export class LandTrendrGraph extends React.Component {
                     highlightSeriesOpts={{
                         highlightCircleSize: 3
                     }}
+                    highlightSeriesBackgroundAlpha={1}
+                    highlightSeriesBackgroundColor={'hsla(0, 0%, 0%, 1)'}
                     errorBars
                     sigma={1}
                     axes={{
@@ -53,32 +61,12 @@ export class LandTrendrGraph extends React.Component {
                     rangeSelectorAlpha={0.2}
                     rangeSelectorBackgroundStrokeColor={'rgba(100%, 100%, 100%, .15)'}
                     rangeSelectorForegroundStrokeColor={'rgba(100%, 100%, 100%, .15)'}
-                    highlightCallback={isMobile() ? undefined : (event, x, points, row) => this.highlightCallback(row)}
+                    highlightCallback={isMobile() ? undefined : this.highlightCallback}
                     unhighlightCallback={isMobile() ? undefined : unhighlightCallback}
                 />
                 {this.renderPoint()}
             </div>
         )
-    }
-
-    calculateData() {
-        const {years, raw, fitted, isVertex} = this.props
-        return years.map((year, i) => [
-            new Date(year, 6, 1),
-            [raw[i], 0],
-            isVertex[i] ? [fitted[i], 0] : null
-        ])
-    }
-
-    highlightCallback(row) {
-        const {years, raw, fitted, isVertex} = this.props
-        this.setState({
-            point: {
-                year: years[row],
-                raw: raw[row],
-                fitted: isVertex[row] ? fitted[row] : null
-            }
-        })
     }
 
     renderPoint() {
@@ -87,7 +75,9 @@ export class LandTrendrGraph extends React.Component {
             return null
         }
         return (
-            <div className={styles.point}>
+            <div
+                className={styles.point}
+                style={point.left ? {right: 0} : null}>
                 <Widget
                     className={styles.year}
                     label={msg('process.landTrendr.mapToolbar.graph.year.label')}>
@@ -109,6 +99,53 @@ export class LandTrendrGraph extends React.Component {
                     : null}
             </div>
         )
+    }
+
+    highlightCallback(event, x, points, row) {
+        const {years, raw, fitted, isVertex} = this.props
+        const point = points[0]
+        this.setState({
+            point: {
+                year: years[row],
+                raw: raw[row],
+                fitted: isVertex[row] ? fitted[row] : null,
+                left: point.x <= 0.5
+            }
+        })
+    }
+
+    componentDidMount() {
+        this.update()
+    }
+
+    componentDidUpdate(prevProps) {
+        this.update(prevProps)
+    }
+
+    // The Graph widget compares data by reference, so rebuilding it on every
+    // render would make dygraph redraw the whole chart on each mouse move.
+    // These arrays come straight out of the charted pixel's segments, so
+    // comparing them is enough to catch a new pixel.
+    update(prevProps = {}) {
+        const {years, raw, fitted, isVertex} = this.props
+        if (years !== prevProps.years
+            || raw !== prevProps.raw
+            || fitted !== prevProps.fitted
+            || isVertex !== prevProps.isVertex) {
+            this.setState({data: this.calculateData()})
+        }
+    }
+
+    calculateData() {
+        const {years, raw, fitted, isVertex} = this.props
+        if (!years || !years.length) {
+            return null
+        }
+        return years.map((year, i) => [
+            new Date(year, 6, 1),
+            [raw[i], 0],
+            isVertex[i] ? [fitted[i], 0] : null
+        ])
     }
 }
 

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.test.js
@@ -55,10 +55,17 @@ it('pins the floating panel to the right when hovering the left half', () => {
     expect(graph.state.point.left).toBe(false)
 })
 
-it('reports the hovered observation, and the fitted value only at a vertex', () => {
+// LandTrendr fits a value for every year in the series, not just the vertices -
+// the vertices are only where the trajectory changes slope.
+it('plots the fitted trajectory for every year', () => {
+    const graph = mount()
+    expect(graph.state.data.map(([, , fitted]) => fitted)).toEqual([[11, 0], [21, 0], [31, 0]])
+})
+
+it('reports the fitted value on a year that is not a vertex', () => {
     const graph = mount()
     graph.highlightCallback(null, null, [{x: 0.5}], 0)
     expect(graph.state.point).toMatchObject({year: 2000, raw: 10, fitted: 11})
     graph.highlightCallback(null, null, [{x: 0.5}], 1)
-    expect(graph.state.point).toMatchObject({year: 2001, raw: 20, fitted: null})
+    expect(graph.state.point).toMatchObject({year: 2001, raw: 20, fitted: 21})
 })

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/panels/landTrendrGraph.test.js
@@ -1,0 +1,64 @@
+import {vi} from 'vitest'
+
+vi.mock('~/translate', () => ({msg: id => id}))
+
+const {LandTrendrGraph} = await import('./landTrendrGraph')
+
+const props = () => ({
+    years: [2000, 2001, 2002],
+    raw: [10, 20, 30],
+    fitted: [11, 21, 31],
+    isVertex: [1, 0, 1]
+})
+
+// Drives the component without rendering: React only ever calls these in this
+// order, and the assertions are about what lands in state.
+const mount = (initialProps = props()) => {
+    const graph = new LandTrendrGraph(initialProps)
+    graph.state = {}
+    graph.setState = update => {
+        const partial = typeof update === 'function' ? update(graph.state) : update
+        graph.state = {...graph.state, ...partial}
+    }
+    graph.componentDidMount()
+    return graph
+}
+
+// The Graph widget compares `data` by reference (widget/graph.jsx), so handing
+// it a freshly built array on every render makes dygraph redraw the whole chart
+// on every mouse move - which is what the hover flicker was.
+it('keeps the same data array while hovering', () => {
+    const graph = mount()
+    const data = graph.state.data
+    expect(data).toBeDefined()
+    graph.highlightCallback(null, null, [{x: 0.4}], 1)
+    graph.componentDidUpdate(graph.props)
+    expect(graph.state.data).toBe(data)
+})
+
+it('rebuilds the data when a different pixel is charted', () => {
+    const graph = mount()
+    const data = graph.state.data
+    const nextProps = {years: [2010, 2011], raw: [1, 2], fitted: [3, 4], isVertex: [1, 1]}
+    const prevProps = graph.props
+    graph.props = nextProps
+    graph.componentDidUpdate(prevProps)
+    expect(graph.state.data).not.toBe(data)
+    expect(graph.state.data).toHaveLength(2)
+})
+
+it('pins the floating panel to the right when hovering the left half', () => {
+    const graph = mount()
+    graph.highlightCallback(null, null, [{x: 0.2}], 1)
+    expect(graph.state.point.left).toBe(true)
+    graph.highlightCallback(null, null, [{x: 0.8}], 1)
+    expect(graph.state.point.left).toBe(false)
+})
+
+it('reports the hovered observation, and the fitted value only at a vertex', () => {
+    const graph = mount()
+    graph.highlightCallback(null, null, [{x: 0.5}], 0)
+    expect(graph.state.point).toMatchObject({year: 2000, raw: 10, fitted: 11})
+    graph.highlightCallback(null, null, [{x: 0.5}], 1)
+    expect(graph.state.point).toMatchObject({year: 2001, raw: 20, fitted: null})
+})

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/selfManagedVisualizations.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/selfManagedVisualizations.test.js
@@ -1,0 +1,10 @@
+import {SELF_MANAGED_VISUALIZATIONS} from '~/app/home/body/process/recipe/recipeImageLayer'
+
+// landTrendrImageLayer reconciles visParams itself, because the available bands
+// differ between the changes and mosaics modes. If the generic reconciliation in
+// recipeImageLayer stays active as well, the two disagree - it picks from the
+// change presets, the layer form picks from the mosaic presets - and they
+// overwrite each other until React aborts with "Maximum update depth exceeded".
+it('leaves visParams reconciliation to the LandTrendr layer form', () => {
+    expect(SELF_MANAGED_VISUALIZATIONS).toContain('LANDTRENDR')
+})

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/visualizations.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/visualizations.js
@@ -1,14 +1,35 @@
+import {visualizationOptions as opticalVisualizationOptions} from '~/app/home/body/process/recipe/opticalMosaic/visualizations'
 import {normalize} from '~/app/home/map/visParams/visParams'
+import {msg} from '~/translate'
 
 import {getAvailableBands} from './bands'
+import {toMosaicRecipe} from './mosaicRecipe'
 
+// Registered on the recipe type, so it feeds the visualization properties
+// attached to exports - which only ever contain change bands.
 export const getPreSetVisualizations = recipe => {
-    const availableBands = getAvailableBands()
-    return visualizations(recipe.model.dates)
+    const availableBands = getAvailableBands(recipe, 'changes')
+    return changeVisualizations(recipe.model.dates)
         .filter(({bands}) => bands.every(band => availableBands[band]))
 }
 
-const visualizations = ({startYear, endYear}) => [
+export const visualizationOptions = (recipe, visualizationType) =>
+    visualizationType === 'mosaics'
+        ? opticalVisualizationOptions(toMosaicRecipe(recipe))
+        : changeVisualizationOptions(recipe)
+
+const changeVisualizationOptions = recipe => {
+    const availableBands = getAvailableBands(recipe, 'changes')
+    return [{
+        label: msg('process.landTrendr.layers.imageLayer.preSets'),
+        options: getPreSetVisualizations(recipe).map(visParams => {
+            const band = visParams.bands[0]
+            return {value: band, label: availableBands[band].label, visParams}
+        })
+    }]
+}
+
+const changeVisualizations = ({startYear, endYear}) => [
     normalize({
         type: 'continuous',
         bands: ['mag'],
@@ -65,20 +86,6 @@ const visualizations = ({startYear, endYear}) => [
         // range, beyond ~10 everything is unambiguous.
         min: [0],
         max: [10],
-        palette: '#FFFFCC, #FEB24C, #F03B20, #BD0026'
-    }),
-    normalize({
-        type: 'rgb',
-        bands: ['startRed', 'startGreen', 'startBlue'],
-        min: [200, 400, 600],
-        max: [2400, 2200, 2400],
-        gamma: [1.2, 1.2, 1.2]
-    }),
-    normalize({
-        type: 'rgb',
-        bands: ['endRed', 'endGreen', 'endBlue'],
-        min: [200, 400, 600],
-        max: [2400, 2200, 2400],
-        gamma: [1.2, 1.2, 1.2]
+        palette: '#000000, #480000, #710101, #BA0000, #FF0000, #FFA500, #FFFF00, #79C900, #006400'
     })
 ]

--- a/modules/gui/src/app/home/body/process/recipe/landTrendr/visualizations.test.js
+++ b/modules/gui/src/app/home/body/process/recipe/landTrendr/visualizations.test.js
@@ -1,0 +1,35 @@
+import {vi} from 'vitest'
+
+vi.mock('~/translate', () => ({msg: id => id}))
+
+const {getPreSetVisualizations, visualizationOptions} = await import('./visualizations')
+
+const recipe = {
+    model: {
+        dates: {startYear: 2000, endYear: 2024},
+        sources: {dataSets: {LANDSAT: ['LANDSAT_8']}},
+        options: {corrections: ['SR']}
+    }
+}
+
+const bandsOf = visualizationType => visualizationOptions(recipe, visualizationType)
+    .flatMap(({options}) => options)
+    .map(({value}) => value)
+
+it('offers the change bands in changes mode', () => {
+    expect(bandsOf('changes')).toEqual(['mag', 'yod', 'dur', 'preval', 'postval', 'rmse', 'sig'])
+})
+
+it('offers the optical mosaic band combinations in mosaics mode', () => {
+    expect(bandsOf('mosaics')).toContain('ndvi')
+})
+
+it('no longer offers the start and end RGB composites', () => {
+    expect(bandsOf('changes')).not.toContain('startRed, startGreen, startBlue')
+    expect(bandsOf('changes')).not.toContain('endRed, endGreen, endBlue')
+})
+
+it('presets used for retrieval cover only the change bands', () => {
+    const bands = getPreSetVisualizations(recipe).flatMap(({bands}) => bands)
+    expect(bands).toEqual(['mag', 'yod', 'dur', 'preval', 'postval', 'rmse', 'sig'])
+})

--- a/modules/gui/src/app/home/body/process/recipe/recipeImageLayer.jsx
+++ b/modules/gui/src/app/home/body/process/recipe/recipeImageLayer.jsx
@@ -22,6 +22,12 @@ const mapStateToProps = (state, {source: {id, sourceConfig: {recipeId}}}) => ({
     recipe: selectFrom(state, ['process.loadedRecipes', recipeId])
 })
 
+// Recipe types whose own image layer form reconciles layerConfig.visParams
+// (selecting a valid visualization when the available bands change). The
+// generic reconciliation below has to stand down for those, or the two writers
+// overwrite each other on every render and React aborts the update loop.
+export const SELF_MANAGED_VISUALIZATIONS = ['CCDC_SLICE', 'CHANGE_ALERTS', 'LANDTRENDR']
+
 class _RecipeImageLayer extends React.Component {
     cursorValue$ = new Subject()
 
@@ -92,7 +98,7 @@ class _RecipeImageLayer extends React.Component {
 
     selfManagedVisualizations() {
         const {recipe} = this.props
-        return recipe && ['CCDC_SLICE', 'CHANGE_ALERTS'].includes(recipe.type)
+        return recipe && SELF_MANAGED_VISUALIZATIONS.includes(recipe.type)
     }
 
     toAllVis() {

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -5145,7 +5145,7 @@
           },
           "mosaics": {
             "label": "Mosaics",
-            "tooltip": "Render the annual composite the algorithm was fitted to"
+            "tooltip": "Render the annual composite for the chosen year"
           }
         },
         "year": {

--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -5134,15 +5134,24 @@
         "preval": "Pre-disturbance value",
         "postval": "Post-disturbance value",
         "rmse": "Fit RMSE",
-        "sig": "Significance (magnitude / RMSE)",
-        "startRed": "Start year - red",
-        "startGreen": "Start year - green",
-        "startBlue": "Start year - blue",
-        "endRed": "End year - red",
-        "endGreen": "End year - green",
-        "endBlue": "End year - blue",
-        "startRgb": "Start year (true color)",
-        "endRgb": "End year (true color)"
+        "sig": "Significance (magnitude / RMSE)"
+      },
+      "imageLayerForm": {
+        "visualizationType": {
+          "label": "Type",
+          "changes": {
+            "label": "Changes",
+            "tooltip": "Render the detected change segment"
+          },
+          "mosaics": {
+            "label": "Mosaics",
+            "tooltip": "Render the annual composite the algorithm was fitted to"
+          }
+        },
+        "year": {
+          "label": "Year",
+          "tooltip": "The year to render a composite for"
+        }
       }
     },
     "samplingDesign": {


### PR DESCRIPTION
`getImage$` now honours the band selection it is passed, returning exactly the requested bands in the requested order — the SEPAL export path names output bands positionally and relies on that.

The fixed start- and end-year RGB composites are replaced by a changes/mosaics switch on the map layer, with a year selector covering the whole segmentation period. Mosaics delegate to a synthetic MOSAIC recipe, so the full optical band and visualization catalogue is available rather than a fixed true-colour triplet, built from the same scenes and corrections as the series the algorithm was fitted to. They are no longer offered for retrieval — an Optical Mosaic recipe is the right way to export that imagery — so the `startRed`…`endBlue` bands are gone from the recipe output.

The pixel chart now follows the CCDC graph implementation: its data is built when the charted pixel changes rather than on every render, which had dygraph redrawing the whole chart on every mouse move. The fitted trajectory is plotted for every year rather than only at vertices.

`recipeImageLayer` now leaves visParams reconciliation to the LandTrendr layer form, as it already does for `CCDC_SLICE` and `CHANGE_ALERTS`.
