### PR TITLE
Supplied CARTODB_BASEMAP_KEY to the sandbox and app-launcher.

### DIFF
--- a/common/src/main/groovy/org/openforis/sepal/util/Config.groovy
+++ b/common/src/main/groovy/org/openforis/sepal/util/Config.groovy
@@ -30,6 +30,11 @@ final class Config {
         return value
     }
 
+    final String string(String key, String defaultValue) {
+        def value = config.getProperty(key)
+        return value == null ? defaultValue : value
+    }
+
     final File file(String key) {
         return new File(string(key))
     }

--- a/modules/app-launcher/docker-compose.yml
+++ b/modules/app-launcher/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       EE_CREDENTIALS_PATH: "${SEPAL_DATA_DIR}/app-launcher/service-account-credentials.json"
       GOOGLE_PROJECT_ID: "${GOOGLE_PROJECT_ID}"
       SEPAL_APPS_CATALOG_URL: "${SEPAL_APPS_CATALOG_URL:-}"
+      CARTODB_BASEMAP_KEY: "${CARTODB_BASEMAP_KEY:-}"
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "80"]
       start_period: 60s

--- a/modules/app-manager/update-app.sh
+++ b/modules/app-manager/update-app.sh
@@ -111,7 +111,9 @@ function update_venv {
         echo "Creating venv: $venv_path" >> "$venv_log_file"
         
         if [[ -f "$app_path/sepal_environment.yml" ]]; then
-             micromamba create -y -p "$venv_path" -f "$app_path/sepal_environment.yml" >> "$venv_log_file"
+             # Root's repodata cache never expires, so a just-published package reads as a typo
+             # until --retry-clean-cache refetches on a failed solve.
+             micromamba create -y --retry-clean-cache -p "$venv_path" -f "$app_path/sepal_environment.yml" >> "$venv_log_file"
              "$venv_path"/bin/pip install ipykernel >> "$venv_log_file"
         else
             python3 -m venv $venv_path

--- a/modules/sandbox/script/init_container.sh
+++ b/modules/sandbox/script/init_container.sh
@@ -44,6 +44,12 @@ if [ -n "$SEPAL_API_KEY" ]; then
     unset SEPAL_API_KEY
 fi
 
+# sepal-ui and pysepal read this with os.getenv() at import time, so unlike SEPAL_API_KEY
+# above it has to stay in the environment the user's processes inherit.
+if [ -n "$CARTODB_BASEMAP_KEY" ]; then
+    printf '%s\n' "CARTODB_BASEMAP_KEY=$CARTODB_BASEMAP_KEY" >> /etc/environment
+fi
+
 printf '%s\n' \
     "R_LIBS_USER=/home/$sandbox_user/.R/library" \
     "R_LIBS_SITE=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library:/shiny/library" \

--- a/modules/sepal-server/config/workerInstance.properties
+++ b/modules/sepal-server/config/workerInstance.properties
@@ -12,6 +12,7 @@ googleProjectId=$GOOGLE_PROJECT_ID
 googleRegion=$GOOGLE_REGION
 googleEarthEngineAccount=$EE_ACCOUNT
 googleEarthEnginePrivateKey=$EE_PRIVATE_KEY
+cartoDbBasemapKey=$CARTODB_BASEMAP_KEY
 rabbitMQHost=rabbitmq
 rabbitMQPort=5672
 deployEnvironment=$DEPLOY_ENVIRONMENT

--- a/modules/sepal-server/docker-compose.yml
+++ b/modules/sepal-server/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       GOOGLE_REGION: "${GOOGLE_REGION}"
       GOOGLE_MAPS_API_KEY: "${GOOGLE_MAPS_API_KEY}"
       NICFI_PLANET_API_KEY: "${NICFI_PLANET_API_KEY}"
+      CARTODB_BASEMAP_KEY: "${CARTODB_BASEMAP_KEY:-}"
     networks:
       - sepal
     healthcheck:

--- a/modules/sepal-server/src/main/groovy/org/openforis/sepal/component/workerinstance/WorkerInstanceConfig.groovy
+++ b/modules/sepal-server/src/main/groovy/org/openforis/sepal/component/workerinstance/WorkerInstanceConfig.groovy
@@ -20,6 +20,7 @@ class WorkerInstanceConfig {
     final String googleRegion
     final String googleEarthEngineAccount
     final String googleEarthEnginePrivateKey
+    final String cartoDbBasemapKey
     final String rabbitMQHost
     final int rabbitMQPort
     final String deployEnvironment
@@ -40,6 +41,7 @@ class WorkerInstanceConfig {
         googleRegion = c.string('googleRegion')
         googleEarthEngineAccount = c.string('googleEarthEngineAccount')
         googleEarthEnginePrivateKey = c.string('googleEarthEnginePrivateKey')
+        cartoDbBasemapKey = c.string('cartoDbBasemapKey')
         rabbitMQHost = c.string('rabbitMQHost')
         rabbitMQPort = c.integer('rabbitMQPort')
         deployEnvironment = c.string('deployEnvironment')

--- a/modules/sepal-server/src/main/groovy/org/openforis/sepal/component/workerinstance/WorkerInstanceConfig.groovy
+++ b/modules/sepal-server/src/main/groovy/org/openforis/sepal/component/workerinstance/WorkerInstanceConfig.groovy
@@ -41,7 +41,7 @@ class WorkerInstanceConfig {
         googleRegion = c.string('googleRegion')
         googleEarthEngineAccount = c.string('googleEarthEngineAccount')
         googleEarthEnginePrivateKey = c.string('googleEarthEnginePrivateKey')
-        cartoDbBasemapKey = c.string('cartoDbBasemapKey')
+        cartoDbBasemapKey = c.string('cartoDbBasemapKey', '')
         rabbitMQHost = c.string('rabbitMQHost')
         rabbitMQPort = c.integer('rabbitMQPort')
         deployEnvironment = c.string('deployEnvironment')

--- a/modules/sepal-server/src/main/groovy/org/openforis/sepal/workertype/WorkerTypes.groovy
+++ b/modules/sepal-server/src/main/groovy/org/openforis/sepal/workertype/WorkerTypes.groovy
@@ -86,6 +86,7 @@ final class WorkerTypes {
                                     USER_PUBLIC_KEY: userPublicKey,
                                     SEPAL_API_KEY: apiKey ?: '',
                                     SEPAL_HOST: config.sepalHost,
+                                    CARTODB_BASEMAP_KEY: config.cartoDbBasemapKey,
                                     NVIDIA_VISIBLE_DEVICES: 'all',
                                     NVIDIA_DRIVER_CAPABILITIES: 'all',
                             ],


### PR DESCRIPTION
`CARTODB_BASEMAP_KEY` is read at import time by sepal-ui 2.22.2 and pysepal 3.8.2, and when unset the maps fall back silently to a keyless Esri layer; the apps' pins are already merged, so the remaining gap was that nothing set it. It now takes the route the other deployment-supplied keys take, through `sepal-server` and `workerInstance.properties` into the sandbox container, where `init_container.sh` appends it to `/etc/environment` so SSH sessions, Jupyter, Voila and Shiny all inherit it. app-launcher passes it to the per-app `docker compose` invocations.

It deliberately does not follow the `SEPAL_API_KEY` pattern directly above it in `init_container.sh`, which writes the secret to a 0600 file and unsets it so nothing inherits it — the opposite of what a variable read via `os.getenv()` needs. It is also a client-side key that appears in every tile URL the browser requests, so it is no more sensitive than `GOOGLE_MAPS_API_KEY`.

Also included: `update-app.sh` runs as root, whose repodata cache never expires, so a freshly published conda-forge package stays invisible and the solve fails as a typo. `--retry-clean-cache` refetches and retries only when a solve fails, so it costs nothing on the happy path.

No value is committed — the key needs adding to the deployment env file, and apps whose own `docker-compose.yml` does not yet forward `CARTODB_BASEMAP_KEY` will need that line in their repos.
