### PR TITLE
wording change: detection rules

### DIFF
--- a/modules/gui/src/locale/en/translations.json
+++ b/modules/gui/src/locale/en/translations.json
@@ -1567,7 +1567,7 @@
           }
         },
         "options": {
-          "title": "Change rules",
+          "title": "Detection rules",
           "button": "OPT",
           "tooltip": "Optional spectral-index confirmation and the temporal-consistency threshold.",
           "form": {


### PR DESCRIPTION
One-word amendment from `change rules` -> `detection rules`.

Making this change in wording as we feel these parameters (the rules) fit better with the intent - giving users options to _detect_ changes, we think that changes should only be labelled as _changes_ once they've been semi-validated through the temporal consistency checks done by this recipe.

@dfguerrerom can you check if okay?