### PR TITLE
Fixed app-launcher proxy route registration.

### DIFF
--- a/modules/app-launcher/src/apiService.js
+++ b/modules/app-launcher/src/apiService.js
@@ -1,4 +1,4 @@
-import {catchError, EMPTY, map} from 'rxjs'
+import {catchError, map, throwError} from 'rxjs'
 
 import {get$} from '#sepal/httpClient'
 import {getLogger} from '#sepal/log'
@@ -16,7 +16,7 @@ const fetchAppsFromApi$ = () => {
         map(response => JSON.parse(response.body)),
         catchError(error => {
             log.error('Failed to fetch apps from API:', error)
-            return EMPTY
+            return throwError(() => error)
         })
     )
 }
@@ -26,7 +26,7 @@ const fetchCatalog$ = url =>
         map(response => JSON.parse(response.body)),
         catchError(error => {
             log.error(`Failed to fetch apps catalog from ${url}:`, error)
-            return EMPTY
+            return throwError(() => error)
         })
     )
 

--- a/modules/app-launcher/src/apps.js
+++ b/modules/app-launcher/src/apps.js
@@ -7,6 +7,7 @@ import {fetchAppsFromApi$, fetchCatalog$} from './apiService.js'
 import {appsCatalogUrl} from './config.js'
 import {buildAndRestart, isContainerRunning, startContainer} from './docker.js'
 import {cloneOrPull} from './git.js'
+import {hasProxies} from './proxy.js'
 import {refreshProxyEndpoints} from './proxyManager.js'
 
 const log = getLogger('apps')
@@ -62,11 +63,14 @@ const updateApp$ = ({path, repository, branch, commit, name}) =>
                     if (!running) {
                         log.info('Containers are not running. Starting them without rebuilding.')
                         return from(startContainer(name)).pipe(
-                            switchMap(() => refreshProxies())
+                            switchMap(() => refreshProxies('container started'))
                         )
                     }
                     log.info('No updates available and containers are running.')
-                    return of(null)
+                    // Startup registration can have failed while the gateway was down. Recover without a restart.
+                    return hasProxies()
+                        ? of(null)
+                        : refreshProxies('no proxy endpoints registered')
                 })
             )
         }),
@@ -76,8 +80,8 @@ const updateApp$ = ({path, repository, branch, commit, name}) =>
         })
     )
 
-const refreshProxies = () => {
-    log.info('Refreshing proxy endpoints after container started...')
+const refreshProxies = reason => {
+    log.info(`Refreshing proxy endpoints: ${reason}`)
     return from(refreshProxyEndpoints()).pipe(
         catchError(error => {
             log.error('Failed to refresh proxy endpoints:', error)

--- a/modules/app-launcher/src/apps.js
+++ b/modules/app-launcher/src/apps.js
@@ -7,8 +7,7 @@ import {fetchAppsFromApi$, fetchCatalog$} from './apiService.js'
 import {appsCatalogUrl} from './config.js'
 import {buildAndRestart, isContainerRunning, startContainer} from './docker.js'
 import {cloneOrPull} from './git.js'
-import {hasProxies} from './proxy.js'
-import {refreshProxyEndpoints} from './proxyManager.js'
+import {hasProxies, refreshProxyEndpoints} from './proxyManager.js'
 
 const log = getLogger('apps')
 

--- a/modules/app-launcher/src/main.js
+++ b/modules/app-launcher/src/main.js
@@ -1,6 +1,7 @@
 import express from 'express'
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import _ from 'lodash'
+import {retry} from 'rxjs'
 
 import logConfig from '#config/log.json' with {type: 'json'}
 import * as server from '#sepal/httpServer'
@@ -17,6 +18,8 @@ import {getRequestUser} from './user.js'
 configureServer(logConfig)
 
 const log = getLogger('main')
+
+const PROXY_RETRY_DELAY_MS = 30 * 1000
 
 const startServer = () => {
     // This is the main server for the app launcher
@@ -46,7 +49,11 @@ const startServer = () => {
     proxyManager.initialize(app, server)
     
     server.setMaxListeners(30)
-    proxyEndpoints$(app).subscribe({
+
+    // The catalog comes from the gateway, which may still be starting. Keep trying, or no app gets a route.
+    proxyEndpoints$(app).pipe(
+        retry({delay: PROXY_RETRY_DELAY_MS})
+    ).subscribe({
         next: proxies => registerUpgradeListener(server, proxies),
         error: error => log.error('Failed to register proxies.', error)
     })

--- a/modules/app-launcher/src/main.js
+++ b/modules/app-launcher/src/main.js
@@ -1,7 +1,6 @@
 import express from 'express'
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import _ from 'lodash'
-import {retry} from 'rxjs'
 
 import logConfig from '#config/log.json' with {type: 'json'}
 import * as server from '#sepal/httpServer'
@@ -11,15 +10,12 @@ import {monitorApps} from './apps.js'
 import {managementPort, monitorEnabled, port} from './config.js'
 import {createCredentialsFile} from './gee.js'
 import managementRoutes from './managementRoutes.js'
-import {proxyEndpoints$, registerUpgradeListener} from './proxy.js'
 import * as proxyManager from './proxyManager.js'
 import {getRequestUser} from './user.js'
 
 configureServer(logConfig)
 
 const log = getLogger('main')
-
-const PROXY_RETRY_DELAY_MS = 30 * 1000
 
 const startServer = () => {
     // This is the main server for the app launcher
@@ -50,11 +46,7 @@ const startServer = () => {
     
     server.setMaxListeners(30)
 
-    // The catalog comes from the gateway, which may still be starting. Keep trying, or no app gets a route.
-    proxyEndpoints$(app).pipe(
-        retry({delay: PROXY_RETRY_DELAY_MS})
-    ).subscribe({
-        next: proxies => registerUpgradeListener(server, proxies),
+    proxyManager.registerProxies$().subscribe({
         error: error => log.error('Failed to register proxies.', error)
     })
 }

--- a/modules/app-launcher/src/proxy.js
+++ b/modules/app-launcher/src/proxy.js
@@ -1,6 +1,6 @@
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import micromatch from 'micromatch'
-import {filter, from, map, switchMap, toArray} from 'rxjs'
+import {filter, from, map, switchMap, tap, toArray} from 'rxjs'
 import url from 'url'
 
 import {getLogger} from '#sepal/log'
@@ -12,13 +12,19 @@ import {getRequestUser, setRequestUser} from './user.js'
 
 const log = getLogger('proxy')
 
+// Every registration path goes through proxyEndpoints$, so this stays in sync with the Express router.
+let registeredProxies = []
+
 const proxyEndpoints$ = expressApp => source$().pipe(
     switchMap(({apps}) => from(apps)),
     filter(({repository}) => repository),
     filter(({endpoint}) => endpoint === 'docker'),
     map(proxy(expressApp)),
-    toArray()
+    toArray(),
+    tap(proxies => registeredProxies = proxies)
 )
+
+const hasProxies = () => registeredProxies.length > 0
 
 const registerUpgradeListener = (server, proxies) => {
     // this was taken from gateway/src/main.js
@@ -50,7 +56,7 @@ const registerUpgradeListener = (server, proxies) => {
     })
 }
 
-export {proxyEndpoints$, registerUpgradeListener}
+export {hasProxies, proxyEndpoints$, registerUpgradeListener}
 
 const proxy = expressApp =>
     ({id, port}) => {

--- a/modules/app-launcher/src/proxy.js
+++ b/modules/app-launcher/src/proxy.js
@@ -1,6 +1,6 @@
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import micromatch from 'micromatch'
-import {filter, from, map, switchMap, tap, toArray} from 'rxjs'
+import {filter, from, map, switchMap, toArray} from 'rxjs'
 import url from 'url'
 
 import {getLogger} from '#sepal/log'
@@ -12,19 +12,13 @@ import {getRequestUser, setRequestUser} from './user.js'
 
 const log = getLogger('proxy')
 
-// Every registration path goes through proxyEndpoints$, so this stays in sync with the Express router.
-let registeredProxies = []
-
-const proxyEndpoints$ = expressApp => source$().pipe(
+const proxyEndpoints$ = router => source$().pipe(
     switchMap(({apps}) => from(apps)),
     filter(({repository}) => repository),
     filter(({endpoint}) => endpoint === 'docker'),
-    map(proxy(expressApp)),
-    toArray(),
-    tap(proxies => registeredProxies = proxies)
+    map(proxy(router)),
+    toArray()
 )
-
-const hasProxies = () => registeredProxies.length > 0
 
 const registerUpgradeListener = (server, proxies) => {
     // this was taken from gateway/src/main.js
@@ -56,15 +50,15 @@ const registerUpgradeListener = (server, proxies) => {
     })
 }
 
-export {hasProxies, proxyEndpoints$, registerUpgradeListener}
+export {proxyEndpoints$, registerUpgradeListener}
 
-const proxy = expressApp =>
+const proxy = router =>
     ({id, port}) => {
         const path = `/${id}`
         const target = `http://${id}:${port}`
 
         // This is to get the resourcez endpoint from solara - only for admin users (it returns the number of active users, etc.)
-        expressApp.use(
+        router.use(
             `${path}/resourcez`,
             (req, res, next) => {
                 const user = getRequestUser(req)
@@ -148,7 +142,7 @@ const proxy = expressApp =>
             }
         })
 
-        expressApp.use(path, proxyMiddleware)
+        router.use(path, proxyMiddleware)
         
         return {path, target, proxy: proxyMiddleware}
     }

--- a/modules/app-launcher/src/proxyManager.js
+++ b/modules/app-launcher/src/proxyManager.js
@@ -1,74 +1,68 @@
+import express from 'express'
+import {firstValueFrom, retry, tap} from 'rxjs'
+
 import {getLogger} from '#sepal/log'
 
 import {proxyEndpoints$, registerUpgradeListener} from './proxy.js'
 
 const log = getLogger('proxyManager')
 
+const REGISTER_RETRY_DELAY_MS = 30 * 1000
+
 let appInstance = null
 let serverInstance = null
 let currentProxies = []
+let activeRouter = express.Router()
 
 const initialize = (app, server) => {
     appInstance = app
     serverInstance = server
+    // Express keeps every layer it is given, and the oldest match wins. Mount one stable layer here and
+    // swap the router behind it, so a refresh replaces the app routes instead of shadowing them.
+    app.use((req, res, next) => activeRouter(req, res, next))
     log.debug('Proxy manager initialized')
 }
 
-const refreshProxyEndpoints = async () => {
+const activate = (router, proxies) => {
+    activeRouter = router
+    currentProxies = proxies
+    if (serverInstance) {
+        serverInstance.removeAllListeners('upgrade')
+        registerUpgradeListener(serverInstance, proxies)
+    }
+}
+
+const proxies$ = () => {
     if (!appInstance) {
         throw new Error('Proxy manager not initialized - Express app not available')
     }
+    const router = express.Router()
+    return proxyEndpoints$(router).pipe(
+        tap(proxies => activate(router, proxies))
+    )
+}
 
-    try {
-        
-        log.info('Refreshing proxy endpoints...')
-        const proxies = await new Promise((resolve, reject) => {
-            proxyEndpoints$(appInstance).subscribe({
-                next: resolve,
-                error: reject
-            })
-        })
-        
-        if (serverInstance) {
-            // Check if proxies actually changed to avoid unnecessary listener updates
-            const hasChanged = !areProxiesEqual(currentProxies, proxies)
-            if (hasChanged) {
-                log.debug('Proxy configuration changed, updating upgrade listeners...')
-                serverInstance.removeAllListeners('upgrade')
-                registerUpgradeListener(serverInstance, proxies)
-                log.info(`Updated upgrade listeners for ${proxies.length} proxy endpoints`)
-            } else {
-                log.debug('Proxy configuration unchanged, skipping listener update')
-            }
-        }
-        
-        currentProxies = proxies
-        
-        log.info(`Refreshed ${proxies.length} proxy endpoints`)
-        return {
-            success: true,
-            count: proxies.length,
-            proxies: proxies.map(p => ({path: p.path, target: p.target}))
-        }
-    } catch (error) {
-        log.error('Failed to refresh proxy endpoints:', error)
-        throw error
+// The catalog comes from the gateway, which may still be starting. Keep trying, or no app gets a route.
+const registerProxies$ = () => proxies$().pipe(
+    retry({delay: REGISTER_RETRY_DELAY_MS})
+)
+
+const refreshProxyEndpoints = async () => {
+    log.info('Refreshing proxy endpoints...')
+    const proxies = await firstValueFrom(proxies$())
+    log.info(`Refreshed ${proxies.length} proxy endpoints`)
+    return {
+        success: true,
+        count: proxies.length,
+        proxies: proxies.map(p => ({path: p.path, target: p.target}))
     }
 }
 
-const areProxiesEqual = (oldProxies, newProxies) => {
-    if (oldProxies.length !== newProxies.length) {
-        return false
-    }
-    
-    const oldPaths = new Set(oldProxies.map(p => `${p.path}:${p.target}`))
-    const newPaths = new Set(newProxies.map(p => `${p.path}:${p.target}`))
-    
-    return oldPaths.size === newPaths.size &&
-           [...oldPaths].every(path => newPaths.has(path))
-}
+const hasProxies = () => currentProxies.length > 0
 
 export {
+    hasProxies,
     initialize,
-    refreshProxyEndpoints
+    refreshProxyEndpoints,
+    registerProxies$
 }


### PR DESCRIPTION
`app-launcher` registers one Express route for each app. The route list comes from the apps catalog, which it fetches through the gateway. Three faults made these routes unreliable.

**The routes were lost when the catalog fetch failed.** The registration runs at start-up. If the gateway was not ready, the fetch failed. `fetchAppsFromApi$` changed that failure into `EMPTY`, so `toArray()` emitted an empty array. The registration completed with zero routes and reported no error. Every app returned 404 until an operator restarted the container. The monitor loop registered the routes again only after it started a stopped container. Because the containers were running, it could not recover.

**A refresh added routes but did not replace them.** `refreshProxyEndpoints()` called `app.use()` again for each app. Express keeps every layer, and the oldest match wins. The new routes were therefore shadowed by the old ones. A refresh could not apply a changed port or target, and the router grew by two layers for each app on each refresh.

**A failed proxy request never got a response.** The error handler guarded the 500 with `Object.keys(res).includes('writeHead')`. `writeHead` lives on the prototype, so the check was always false and the branch was dead. With an app container down, the request hung until the client timed out.

Changes:
- The catalog fetch propagates the error. It no longer returns `EMPTY`.
- The start-up registration retries every 30 seconds until the catalog responds.
- The registration is deferred, so a retry builds a new router instead of reusing the one that failed.
- The monitor registers the routes again when no proxy endpoint exists.
- `proxyManager` mounts one stable Express layer and swaps the router behind it. A refresh now replaces the app routes.
- `proxyManager` owns all registration. Start-up and refresh use the same code path.
- A proxy error ends the response, matching `gateway`. A websocket upgrade failure closes the socket.

Tested on a dev instance. Removing an app from the catalog and restarting leaves that app without a route while the others keep theirs. Adding it back starts the container and registers the route within one monitor cycle, with no restart. Changing an app's port in the catalog moves traffic to the new port; before, the stale route kept winning and the change was silently ignored. With the container stopped, a request now returns 500 in under 20 ms, where it previously hung until the client timed out.
