### PR TITLE
changed colour palettes for PyEO presets

### DIFF
--- a/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/visualizations.js
+++ b/modules/gui/src/app/home/body/process/recipe/pyeoAlerts/visualizations.js
@@ -5,7 +5,7 @@ import {selectFrom} from '~/stateUtils'
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 
-const DATE_PALETTE = ['#000000', '#781C81', '#3F60AE', '#539EB6', '#6DB388', '#CAB843', '#E78532', '#D92120']
+const DATE_PALETTE = ['#DBEAFE', '#0FA2F5']
 
 const toFractionalYear = (date, fallback) => {
     const m = moment(date, DATE_FORMAT, true)
@@ -24,14 +24,14 @@ export const getPreSetVisualizations = recipe => {
             bands: ['total_changes'],
             min: 0,
             max: 10,
-            palette: ['#ffffbf', '#d7191c']
+            palette: ['#FFFFFF', '#F70C1E']
         }),
         normalize({
             type: 'continuous',
             bands: ['post_fcd_change_repeatability_pct'],
             min: 0,
             max: 100,
-            palette: ['#ffffd4', '#fed98e', '#fe9929', '#d95f0e', '#993404']
+            palette: ['#DCFCE7', '#17B356']
         }),
         normalize({
             type: 'continuous',


### PR DESCRIPTION
Changed the colour palettes for the visualisations for PyEO's three preset bands:

- `total_changes`
- `post_fcd_change_repeatability_pct`
- `fcd_decision_map`

The colour palettes are now linear from a lighter colour shade to a darker shade of the same colour, except for `total_changes` where white maps to 0 for no changes.